### PR TITLE
fix: rule-triggered deletions properly tracked in history and activity log

### DIFF
--- a/server/src/db/repositories/history.ts
+++ b/server/src/db/repositories/history.ts
@@ -29,7 +29,9 @@ export interface HistoryItem {
   type: 'movie' | 'tv';
   size: number | null;
   deletedAt: string;
-  deletedBy: string;
+  deletionReason: 'rule' | 'manual';
+  matchedRule?: string;
+  ruleId?: number;
 }
 
 export interface HistoryQueryParams {
@@ -51,14 +53,24 @@ export interface HistoryQueryResult {
 }
 
 function rowToHistoryItem(row: DeletionHistoryRow, ruleName?: string): HistoryItem {
+  // Server stores shows as 'show', client UI expects 'tv'. Episode-type entries
+  // also roll up to 'tv' for presentation purposes.
+  const clientType = row.type === 'movie' ? 'movie' : 'tv';
+
+  // A deletion is rule-attributed when we have a specific rule ID, regardless
+  // of whether deletion_type is 'automatic' (scheduled) or 'manual' (queue processed by user).
+  const isRuleDeletion = row.deleted_by_rule_id !== null;
+
   return {
     id: row.id,
     mediaId: row.media_item_id,
     title: row.title,
-    type: row.type as 'movie' | 'tv',
+    type: clientType,
     size: row.file_size,
     deletedAt: row.deleted_at,
-    deletedBy: ruleName || (row.deletion_type === 'manual' ? 'manual' : 'rule'),
+    deletionReason: isRuleDeletion ? 'rule' : 'manual',
+    ...(ruleName ? { matchedRule: ruleName } : {}),
+    ...(row.deleted_by_rule_id !== null ? { ruleId: row.deleted_by_rule_id } : {}),
   };
 }
 
@@ -200,7 +212,7 @@ export function getAllHistoryForExport(params: Omit<HistoryQueryParams, 'page' |
 }
 
 export function generateCsv(items: HistoryItem[]): string {
-  const headers = ['ID', 'Media ID', 'Title', 'Type', 'Size (bytes)', 'Deleted At', 'Deleted By'];
+  const headers = ['ID', 'Media ID', 'Title', 'Type', 'Size (bytes)', 'Deleted At', 'Reason', 'Rule'];
   const rows = items.map((item) => [
     item.id.toString(),
     item.mediaId?.toString() ?? '',
@@ -208,7 +220,8 @@ export function generateCsv(items: HistoryItem[]): string {
     item.type,
     item.size?.toString() ?? '',
     item.deletedAt,
-    item.deletedBy,
+    item.deletionReason,
+    item.matchedRule ? `"${item.matchedRule.replace(/"/g, '""')}"` : '',
   ]);
 
   return [headers.join(','), ...rows.map((row) => row.join(','))].join('\n');

--- a/server/src/routes/scan.ts
+++ b/server/src/routes/scan.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 import rulesRepo from '../db/repositories/rules';
 import mediaItemsRepo from '../db/repositories/mediaItems';
 import { logActivity } from '../db/repositories/activity';
-import { loadExclusionPatterns, matchesExclusionPattern } from '../scheduler/tasks';
+import { loadExclusionPatterns, matchesExclusionPattern, queueItemForDeletion } from '../scheduler/tasks';
 import logger from '../utils/logger';
 
 const router = Router();
@@ -200,7 +200,7 @@ async function executeScan(scanId: number): Promise<void> {
               itemsFlagged++;
               break;
             case 'delete':
-              mediaItemsRepo.updateStatus(item.id, 'pending_deletion');
+              queueItemForDeletion(item as any, rule);
               itemsFlagged++;
               break;
             case 'notify':

--- a/server/src/scheduler/tasks.ts
+++ b/server/src/scheduler/tasks.ts
@@ -162,6 +162,71 @@ function evaluateConditions(
 }
 
 // ============================================================================
+// Rule-triggered deletion queueing
+// ============================================================================
+
+/**
+ * Queue a media item for deletion based on a rule match.
+ * Sets all the metadata required by the deletion queue (marked_at, delete_after,
+ * deletion_action, reset_overseerr, matched_rule_id) and logs to activity.
+ *
+ * Shared between scheduled scans (scheduler/tasks.ts) and manual scans (routes/scan.ts)
+ * so rule-triggered deletions properly flow through the queue → history → notifications.
+ */
+export function queueItemForDeletion(
+  item: MediaItem,
+  rule: {
+    id: number;
+    name: string;
+    grace_period_days: number | null;
+    deletion_action: string | null;
+    reset_overseerr: boolean;
+  }
+): void {
+  const gracePeriodDays = rule.grace_period_days ?? 7;
+  const deletionAction = rule.deletion_action ?? 'unmonitor_and_delete';
+  const resetOverseerr = rule.reset_overseerr ? 1 : 0;
+
+  const now = new Date();
+  const deleteAfter = new Date(now);
+  deleteAfter.setDate(deleteAfter.getDate() + gracePeriodDays);
+
+  // Preserve existing marked_at if the item is already queued (idempotent re-runs)
+  const isAlreadyQueued = item.status === 'pending_deletion';
+  const markedAt = isAlreadyQueued ? (item.marked_at ?? now.toISOString()) : now.toISOString();
+
+  mediaItemsRepo.update(item.id, {
+    status: 'pending_deletion',
+    marked_at: markedAt,
+    delete_after: deleteAfter.toISOString(),
+    deletion_action: deletionAction,
+    reset_overseerr: resetOverseerr,
+    matched_rule_id: rule.id,
+  } as any);
+
+  try {
+    logActivity({
+      eventType: 'rule_match',
+      action: 'item_queued',
+      actorType: 'rule',
+      actorId: rule.id.toString(),
+      actorName: rule.name,
+      targetType: 'media_item',
+      targetId: item.id,
+      targetTitle: item.title,
+      metadata: JSON.stringify({
+        gracePeriodDays,
+        deleteAfter: deleteAfter.toISOString(),
+        deletionAction,
+        resetOverseerr: Boolean(resetOverseerr),
+      }),
+    });
+  } catch (activityError) {
+    logger.warn('Failed to log activity for rule-triggered queue:', activityError);
+  }
+}
+
+// ============================================================================
 // Library Scan Task
 // ============================================================================
 
@@ -255,7 +320,7 @@ export async function scanLibraries(): Promise<ScanResult> {
               itemsFlagged++;
               break;
             case 'delete':
-              mediaItemsRepo.updateStatus(item.id, 'pending_deletion');
+              queueItemForDeletion(item, rule);
               itemsFlagged++;
               break;
             case 'notify':


### PR DESCRIPTION
## Summary

Fixes #20 — deletions triggered by scheduled rules were invisible to the queue processor, so they never reached Deletion History, showed up in the Activity Log's rule filter, or fired a Discord deletion notification.

## Root cause

**Two related bugs compounding each other:**

1. **Scan paths bypassed the queue metadata contract.**
   Both `scheduler/tasks.ts` and `routes/scan.ts` marked rule-matched items as `pending_deletion` using `updateStatus()`, which only touches the `status` column. The queue processor filters on `delete_after`, so items without it were silently discarded. No `matched_rule_id` was set either — so even in the unlikely event they did get deleted, rule attribution was lost.

2. **History API contract mismatch.**
   Server returned `{ deletedBy: string }` while the UI consumed `{ deletionReason: 'rule' | 'manual', matchedRule?: string }`. Even legitimately rule-triggered entries displayed as "Manual".

## Fix

- Introduced `queueItemForDeletion()` helper in `scheduler/tasks.ts` that sets the full queue metadata (`marked_at`, `delete_after`, `deletion_action`, `reset_overseerr`, `matched_rule_id`) and writes an `item_queued` activity entry attributed to the rule. Idempotent on re-runs (preserves `marked_at`).
- Both scan paths (scheduled and manual trigger) now use this helper.
- Updated `rowToHistoryItem` to emit the structured fields the UI expects, and map the server's `show`/`episode` media type to the client's `tv`.

## Flow after fix

`scan` → `queueItemForDeletion()` writes queue metadata + activity log → `processDeletionQueue` task picks it up at grace expiry → `DeletionService.executeDelete()` deletes + writes history row with rule ID + activity log `deleted` entry → Discord notification fires.

## Test plan

- [x] `npm run build` clean on server and client
- [x] 38 server + 35 client tests pass
- [ ] Manually verify: create a test rule with short grace period, run scheduled scan, confirm items appear in Queue with rule attribution
- [ ] After grace expiry, confirm items are deleted and appear in Deletion History with the rule name
- [ ] Activity Log filtered by "Rule" actor shows both `item_queued` and `deleted` events
- [ ] Discord notification fires on deletion completion