### PR TITLE
feat: schedule periodic Plex library sync

### DIFF
--- a/client/src/components/Dashboard/Dashboard.tsx
+++ b/client/src/components/Dashboard/Dashboard.tsx
@@ -180,6 +180,8 @@ export default function Dashboard() {
               nextRun: null,
               scanSchedule: '0 3 * * *',
               lastSync: null,
+              lastSyncAt: null,
+              lastSyncSuccess: null,
               nextSync: null,
               syncSchedule: '0 2 * * *',
             }}

--- a/client/src/components/Dashboard/Dashboard.tsx
+++ b/client/src/components/Dashboard/Dashboard.tsx
@@ -179,6 +179,9 @@ export default function Dashboard() {
               lastScan: null,
               nextRun: null,
               scanSchedule: '0 3 * * *',
+              lastSync: null,
+              nextSync: null,
+              syncSchedule: '0 2 * * *',
             }}
             loading={healthLoading}
           />

--- a/client/src/components/Settings/Settings.tsx
+++ b/client/src/components/Settings/Settings.tsx
@@ -495,6 +495,19 @@ export default function Settings() {
     }));
   };
 
+  const handlePlexSyncChange = (field: keyof NonNullable<SettingsType['plexSync']>, value: string | number | boolean) => {
+    setLocalSettings((prev) => ({
+      ...prev,
+      plexSync: {
+        enabled: prev.plexSync?.enabled ?? currentSettings.plexSync?.enabled ?? true,
+        interval: prev.plexSync?.interval ?? currentSettings.plexSync?.interval ?? 'daily',
+        time: prev.plexSync?.time ?? currentSettings.plexSync?.time ?? '02:00',
+        dayOfWeek: prev.plexSync?.dayOfWeek ?? currentSettings.plexSync?.dayOfWeek ?? 0,
+        [field]: value,
+      },
+    }));
+  };
+
   // Export/Import handlers
   const handleExport = async () => {
     try {
@@ -906,6 +919,92 @@ export default function Settings() {
                     />
                   </div>
                 </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Plex Library Sync Schedule */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-sky-500/10">
+              <RefreshCw className="w-5 h-5 text-sky-400" />
+            </div>
+            <div>
+              <CardTitle>Plex Library Sync</CardTitle>
+              <CardDescription>Automatically pull new movies and shows from Plex into Prunerr</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex items-center justify-between p-4 rounded-xl bg-surface-800/40 border border-surface-700/30">
+            <div>
+              <p className="font-medium text-surface-50">Automatic Plex Sync</p>
+              <p className="text-sm text-surface-400 mt-0.5">
+                Refresh the library from Plex so new items appear without clicking "Sync Library"
+              </p>
+            </div>
+            <ToggleSwitch
+              checked={currentSettings.plexSync?.enabled ?? true}
+              onChange={(checked) => handlePlexSyncChange('enabled', checked)}
+            />
+          </div>
+
+          {(currentSettings.plexSync?.enabled ?? true) && (
+            <div className={cn(
+              'grid gap-4 pl-4 border-l-2 border-sky-500/30',
+              currentSettings.plexSync?.interval === 'weekly'
+                ? 'grid-cols-1 md:grid-cols-3'
+                : 'grid-cols-1 md:grid-cols-2'
+            )}>
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-surface-200">
+                  Sync Interval
+                </label>
+                <select
+                  value={currentSettings.plexSync?.interval || 'daily'}
+                  onChange={(e) => handlePlexSyncChange('interval', e.target.value)}
+                  className="select"
+                >
+                  <option value="hourly">Every hour (at :00)</option>
+                  <option value="daily">Once per day</option>
+                  <option value="weekly">Once per week</option>
+                </select>
+              </div>
+              {currentSettings.plexSync?.interval === 'weekly' && (
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-surface-200">
+                    Day of Week
+                  </label>
+                  <select
+                    value={currentSettings.plexSync?.dayOfWeek ?? 0}
+                    onChange={(e) => handlePlexSyncChange('dayOfWeek', parseInt(e.target.value))}
+                    className="select"
+                  >
+                    <option value={0}>Sunday</option>
+                    <option value={1}>Monday</option>
+                    <option value={2}>Tuesday</option>
+                    <option value={3}>Wednesday</option>
+                    <option value={4}>Thursday</option>
+                    <option value={5}>Friday</option>
+                    <option value={6}>Saturday</option>
+                  </select>
+                </div>
+              )}
+              <div className="space-y-2">
+                <Input
+                  label="Sync Time"
+                  type="time"
+                  value={currentSettings.plexSync?.time || '02:00'}
+                  onChange={(e) => handlePlexSyncChange('time', e.target.value)}
+                />
+                <p className="text-xs text-surface-500">
+                  {currentSettings.plexSync?.interval === 'hourly'
+                    ? 'Sync will run at this minute past each hour'
+                    : 'Run before your scan so rules see the latest catalog'}
+                </p>
               </div>
             </div>
           )}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -291,6 +291,13 @@ export interface ScheduleSettings {
   historyLookbackDays?: number;
 }
 
+export interface PlexSyncSettings {
+  enabled: boolean;
+  interval: 'hourly' | 'daily' | 'weekly';
+  time: string;
+  dayOfWeek?: number;  // 0-6, Sunday=0, only used when interval='weekly'
+}
+
 export interface DisplaySettings {
   dateFormat: 'relative' | 'absolute' | 'iso';
   timeFormat: '12h' | '24h';
@@ -309,6 +316,7 @@ export interface Settings {
   };
   notifications?: NotificationSettings;
   schedule?: ScheduleSettings;
+  plexSync?: PlexSyncSettings;
   display?: DisplaySettings;
   exclusionPatterns?: Array<{ field: string; operator: string; value: string }>;
   excludedLibraryKeys?: string[];
@@ -401,6 +409,9 @@ export interface SchedulerStatus {
   lastScan: string | null;
   nextRun: string | null;
   scanSchedule: string;
+  lastSync: string | null;
+  nextSync: string | null;
+  syncSchedule: string;
 }
 
 export interface SystemHealthResponse {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -409,7 +409,9 @@ export interface SchedulerStatus {
   lastScan: string | null;
   nextRun: string | null;
   scanSchedule: string;
-  lastSync: string | null;
+  lastSync: string | null;           // last successful Plex sync
+  lastSyncAt: string | null;         // last sync attempt finish (success OR failure)
+  lastSyncSuccess: boolean | null;
   nextSync: string | null;
   syncSchedule: string;
 }

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -7,6 +7,7 @@ import logger from '../utils/logger';
 import { getScheduler } from '../scheduler';
 import * as scanHistoryRepo from '../db/repositories/scanHistoryRepo';
 import { getPlexService, getRadarrService, getSonarrService, getTautulliService, getTracearrService, getOverseerrService } from '../services/init';
+import { getLastSyncCompletedAt } from '../services/syncCoordinator';
 
 // Read version from environment variable (set at Docker build time) or fallback to package.json
 let appVersion = process.env['APP_VERSION'] || '1.0.0';
@@ -134,6 +135,9 @@ interface SchedulerStatus {
   lastScan: string | null;
   nextRun: string | null;
   scanSchedule: string;
+  lastSync: string | null;
+  nextSync: string | null;
+  syncSchedule: string;
 }
 
 interface SystemHealthResponse {
@@ -221,10 +225,12 @@ router.get('/status', async (_req: Request, res: Response) => {
     // Get scheduler info
     const scheduler = getScheduler();
     const scanJobStatus = scheduler.getJobStatus('scanLibraries');
+    const syncJobStatus = scheduler.getJobStatus('syncPlexLibrary');
     const schedulerConfig = scheduler.getConfig();
 
     // Get last scan from history
     const latestScan = scanHistoryRepo.getLatest();
+    const lastSyncCompletedAt = getLastSyncCompletedAt();
 
     const response: SystemHealthResponse = {
       services,
@@ -233,6 +239,9 @@ router.get('/status', async (_req: Request, res: Response) => {
         lastScan: latestScan?.completed_at || latestScan?.started_at || null,
         nextRun: scanJobStatus?.nextRun?.toISOString() || null,
         scanSchedule: schedulerConfig.schedules.scanLibraries,
+        lastSync: lastSyncCompletedAt?.toISOString() || null,
+        nextSync: syncJobStatus?.nextRun?.toISOString() || null,
+        syncSchedule: schedulerConfig.schedules.syncPlexLibrary,
       },
       overall: determineOverallHealth(services),
     };

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -7,7 +7,11 @@ import logger from '../utils/logger';
 import { getScheduler } from '../scheduler';
 import * as scanHistoryRepo from '../db/repositories/scanHistoryRepo';
 import { getPlexService, getRadarrService, getSonarrService, getTautulliService, getTracearrService, getOverseerrService } from '../services/init';
-import { getLastSyncCompletedAt } from '../services/syncCoordinator';
+import {
+  getLastSyncCompletedAt,
+  getLastSyncFinishedAt,
+  getLastSyncSuccess,
+} from '../services/syncCoordinator';
 
 // Read version from environment variable (set at Docker build time) or fallback to package.json
 let appVersion = process.env['APP_VERSION'] || '1.0.0';
@@ -135,7 +139,9 @@ interface SchedulerStatus {
   lastScan: string | null;
   nextRun: string | null;
   scanSchedule: string;
-  lastSync: string | null;
+  lastSync: string | null;          // last successful Plex sync
+  lastSyncAt: string | null;        // last sync attempt finish (success OR failure)
+  lastSyncSuccess: boolean | null;  // whether that finish was a success
   nextSync: string | null;
   syncSchedule: string;
 }
@@ -231,6 +237,8 @@ router.get('/status', async (_req: Request, res: Response) => {
     // Get last scan from history
     const latestScan = scanHistoryRepo.getLatest();
     const lastSyncCompletedAt = getLastSyncCompletedAt();
+    const lastSyncFinishedAt = getLastSyncFinishedAt();
+    const lastSyncSuccess = getLastSyncSuccess();
 
     const response: SystemHealthResponse = {
       services,
@@ -240,6 +248,8 @@ router.get('/status', async (_req: Request, res: Response) => {
         nextRun: scanJobStatus?.nextRun?.toISOString() || null,
         scanSchedule: schedulerConfig.schedules.scanLibraries,
         lastSync: lastSyncCompletedAt?.toISOString() || null,
+        lastSyncAt: lastSyncFinishedAt?.toISOString() || null,
+        lastSyncSuccess,
         nextSync: syncJobStatus?.nextRun?.toISOString() || null,
         syncSchedule: schedulerConfig.schedules.syncPlexLibrary,
       },

--- a/server/src/routes/library.ts
+++ b/server/src/routes/library.ts
@@ -4,40 +4,17 @@ import mediaItemsRepo from '../db/repositories/mediaItems';
 import collectionsRepo from '../db/repositories/collections';
 import settingsRepo from '../db/repositories/settings';
 import { logActivity } from '../db/repositories/activity';
-import { ScannerService } from '../services/scanner';
 import { getPlexService } from '../services/init';
+import {
+  isSyncInProgress,
+  runLibrarySync,
+  subscribeToSync,
+  getSyncProgressLog,
+} from '../services/syncCoordinator';
 import logger from '../utils/logger';
 import { formatBytes } from '../utils/format';
 
 const router = Router();
-
-// Scanner service instance for library sync
-let scannerService: ScannerService | null = null;
-
-// Get or create scanner service
-function getScanner(): ScannerService {
-  if (!scannerService) {
-    scannerService = new ScannerService();
-    // Set up database callback for syncing
-    scannerService.setDatabaseCallback(async (items) => {
-      for (const item of items) {
-        const input = scannerService!.convertToMediaItemInput(item);
-        const existingItem = input.plex_id ? mediaItemsRepo.getByPlexId(input.plex_id) : null;
-        if (existingItem) {
-          // Strip status so a sync never clobbers queue/protection state.
-          const { status, ...plexFields } = input;
-          mediaItemsRepo.update(existingItem.id, plexFields);
-        } else {
-          mediaItemsRepo.create(input);
-        }
-      }
-    });
-  }
-  return scannerService;
-}
-
-// In-memory flag to prevent concurrent syncs
-let syncInProgress = false;
 
 // Query parameter schema for library filtering
 const LibraryFiltersSchema = z.object({
@@ -582,7 +559,7 @@ router.get('/sync/status', (_req: Request, res: Response) => {
   res.json({
     success: true,
     data: {
-      inProgress: syncInProgress,
+      inProgress: isSyncInProgress(),
     },
   });
 });
@@ -635,8 +612,7 @@ router.get('/:id', (req: Request, res: Response) => {
 
 // POST /api/library/sync - Sync library from Plex (trigger a scan)
 router.post('/sync', async (_req: Request, res: Response) => {
-  // Check if sync is already in progress
-  if (syncInProgress) {
+  if (isSyncInProgress()) {
     res.status(409).json({
       success: false,
       error: 'A sync is already in progress',
@@ -644,52 +620,29 @@ router.post('/sync', async (_req: Request, res: Response) => {
     return;
   }
 
-  syncInProgress = true;
-
-  // Return immediately - sync runs asynchronously
   res.status(202).json({
     success: true,
     message: 'Library sync started',
   });
 
-  // Execute sync asynchronously
-  try {
-    const scanner = getScanner();
-    // Reinitialize to pick up any settings changes
-    scanner.reinitialize();
-    const result = await scanner.scanAll();
+  const outcome = await runLibrarySync();
+  if (outcome.status === 'completed' && outcome.result) {
     logger.info('Library sync completed', {
-      itemsScanned: result.itemsScanned,
-      itemsAdded: result.itemsAdded,
-      itemsUpdated: result.itemsUpdated,
-      errors: result.errors.length,
+      itemsScanned: outcome.result.itemsScanned,
+      itemsAdded: outcome.result.itemsAdded,
+      itemsUpdated: outcome.result.itemsUpdated,
+      errors: outcome.result.errors.length,
     });
-  } catch (error) {
-    logger.error('Library sync failed:', error);
-  } finally {
-    syncInProgress = false;
   }
 });
 
-// Sync progress broadcasting — allows multiple clients to receive progress from a single sync
-const syncProgressLog: unknown[] = [];
-const syncListeners = new Set<(data: unknown) => void>();
-
-function broadcastProgress(data: unknown): void {
-  syncProgressLog.push(data);
-  for (const listener of syncListeners) {
-    try { listener(data); } catch { /* client disconnected */ }
-  }
-}
-
 // GET /api/library/sync/stream - Subscribe to in-progress sync events (reconnect-safe)
-router.get('/sync/stream', (_req: Request, res: Response) => {
-  if (!syncInProgress) {
+router.get('/sync/stream', (req: Request, res: Response) => {
+  if (!isSyncInProgress()) {
     res.status(204).end();
     return;
   }
 
-  // Set up SSE headers
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
@@ -697,25 +650,22 @@ router.get('/sync/stream', (_req: Request, res: Response) => {
   res.flushHeaders();
 
   // Replay buffered events so the client catches up
-  for (const event of syncProgressLog) {
+  for (const event of getSyncProgressLog()) {
     res.write(`data: ${JSON.stringify(event)}\n\n`);
   }
 
-  // Listen for new events
-  const listener = (data: unknown) => {
+  const unsubscribe = subscribeToSync((data) => {
     res.write(`data: ${JSON.stringify(data)}\n\n`);
-  };
-  syncListeners.add(listener);
+  });
 
-  // Clean up on disconnect
-  _req.on('close', () => {
-    syncListeners.delete(listener);
+  req.on('close', () => {
+    unsubscribe();
   });
 });
 
 // POST /api/library/sync/stream - Start sync with SSE progress streaming
 router.post('/sync/stream', async (_req: Request, res: Response) => {
-  if (syncInProgress) {
+  if (isSyncInProgress()) {
     res.status(409).json({
       success: false,
       error: 'A sync is already in progress',
@@ -723,51 +673,28 @@ router.post('/sync/stream', async (_req: Request, res: Response) => {
     return;
   }
 
-  syncInProgress = true;
-  syncProgressLog.length = 0; // Clear previous log
-
-  // Set up SSE headers
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
   res.setHeader('X-Accel-Buffering', 'no');
   res.flushHeaders();
 
-  // This client is also a listener
-  const sendToSelf = (data: unknown) => {
+  const unsubscribe = subscribeToSync((data) => {
     res.write(`data: ${JSON.stringify(data)}\n\n`);
-  };
-  syncListeners.add(sendToSelf);
+  });
 
   try {
-    const scanner = getScanner();
-    scanner.reinitialize();
-
-    const result = await scanner.scanAll((progress) => {
-      broadcastProgress(progress);
-    });
-
-    logger.info('Library sync completed (streamed)', {
-      itemsScanned: result.itemsScanned,
-      itemsAdded: result.itemsAdded,
-      itemsUpdated: result.itemsUpdated,
-      errors: result.errors.length,
-    });
-  } catch (error) {
-    logger.error('Library sync failed:', error);
-    broadcastProgress({
-      stage: 'error',
-      message: `Sync failed: ${error instanceof Error ? error.message : String(error)}`,
-      result: { success: false, itemsScanned: 0, itemsAdded: 0, itemsUpdated: 0, errors: 1 },
-    });
-  } finally {
-    syncInProgress = false;
-    syncListeners.delete(sendToSelf);
-    // Close all remaining listeners
-    for (const listener of syncListeners) {
-      try { listener({ stage: 'complete', message: 'Sync stream ended' }); } catch { /* ignore */ }
+    const outcome = await runLibrarySync();
+    if (outcome.status === 'completed' && outcome.result) {
+      logger.info('Library sync completed (streamed)', {
+        itemsScanned: outcome.result.itemsScanned,
+        itemsAdded: outcome.result.itemsAdded,
+        itemsUpdated: outcome.result.itemsUpdated,
+        errors: outcome.result.errors.length,
+      });
     }
-    syncListeners.clear();
+  } finally {
+    unsubscribe();
     res.end();
   }
 });

--- a/server/src/routes/library.ts
+++ b/server/src/routes/library.ts
@@ -656,6 +656,11 @@ router.get('/sync/stream', (req: Request, res: Response) => {
 
   const unsubscribe = subscribeToSync((data) => {
     res.write(`data: ${JSON.stringify(data)}\n\n`);
+    // Close the stream once the coordinator emits its final 'complete' sentinel
+    // so the server doesn't hold the SSE connection open after the sync ends.
+    if ((data as { stage?: string } | null)?.stage === 'complete') {
+      res.end();
+    }
   });
 
   req.on('close', () => {

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -32,6 +32,7 @@ const KNOWN_SETTING_PREFIXES = [
   'unraid_',
   'notifications_',
   'schedule_',
+  'plexSync_',
   'display_',
   'exclusion_',
   'excluded_library_',
@@ -69,6 +70,7 @@ router.get('/', (_req: Request, res: Response) => {
     const services: Record<string, Record<string, string>> = {};
     const notifications: Record<string, string | boolean> = {};
     const schedule: Record<string, string | boolean | number> = {};
+    const plexSync: Record<string, string | boolean | number> = {};
     const display: Record<string, string> = {};
     let exclusionPatterns: unknown[] = [];
     let excludedLibraryKeys: string[] = [];
@@ -124,6 +126,19 @@ router.get('/', (_req: Request, res: Response) => {
         continue;
       }
 
+      // Parse Plex sync settings
+      if (key.startsWith('plexSync_')) {
+        const field = key.replace('plexSync_', '');
+        if (value === 'true' || value === 'false') {
+          plexSync[field] = value === 'true';
+        } else if (!isNaN(Number(value)) && field !== 'time') {
+          plexSync[field] = Number(value);
+        } else {
+          plexSync[field] = value;
+        }
+        continue;
+      }
+
       // Parse display settings
       if (key.startsWith('display_')) {
         const field = key.replace('display_', '');
@@ -138,6 +153,7 @@ router.get('/', (_req: Request, res: Response) => {
         services,
         notifications,
         schedule,
+        plexSync,
         display,
         exclusionPatterns,
         excludedLibraryKeys,
@@ -385,6 +401,17 @@ router.put('/', async (req: Request, res: Response) => {
       }
     }
 
+    // Save Plex sync configuration
+    if (settings.plexSync) {
+      for (const [field, value] of Object.entries(settings.plexSync)) {
+        if (value !== undefined && value !== null) {
+          const key = `plexSync_${field}`;
+          settingsRepo.set({ key, value: String(value) });
+          savedSettings.push({ key, value: String(value) });
+        }
+      }
+    }
+
     // Save display configuration
     if (settings.display) {
       for (const [field, value] of Object.entries(settings.display)) {
@@ -396,8 +423,10 @@ router.put('/', async (req: Request, res: Response) => {
       }
     }
 
-    // Update scheduler if schedule settings were changed
-    const hasScheduleSettings = savedSettings.some(s => s.key.startsWith('schedule_'));
+    // Update scheduler if schedule or Plex sync settings were changed
+    const hasScheduleSettings = savedSettings.some(
+      s => s.key.startsWith('schedule_') || s.key.startsWith('plexSync_')
+    );
     if (hasScheduleSettings) {
       try {
         const scheduler = getScheduler();
@@ -447,6 +476,39 @@ router.put('/', async (req: Request, res: Response) => {
         } else if (autoProcess === true) {
           scheduler.enableTask('processDeletionQueue');
           logger.info('Auto-process deletion queue enabled');
+        }
+
+        // Handle Plex library sync schedule
+        if (settings.plexSync !== undefined) {
+          const plexSyncEnabled = settings.plexSync?.enabled;
+
+          if (plexSyncEnabled === false) {
+            scheduler.disableTask('syncPlexLibrary');
+            logger.info('Scheduled Plex library sync disabled');
+          } else {
+            const psInterval = settings.plexSync?.interval || 'daily';
+            const psTime = settings.plexSync?.time || '02:00';
+            const psDayOfWeek = settings.plexSync?.dayOfWeek;
+            const [psHour, psMinute] = psTime.split(':').map(Number);
+
+            let psCron: string;
+            switch (psInterval) {
+              case 'hourly':
+                psCron = `${psMinute} * * * *`;
+                break;
+              case 'weekly':
+                psCron = `${psMinute} ${psHour} * * ${psDayOfWeek ?? 0}`;
+                break;
+              case 'daily':
+              default:
+                psCron = `${psMinute} ${psHour} * * *`;
+                break;
+            }
+
+            scheduler.enableTask('syncPlexLibrary');
+            scheduler.updateSchedule('syncPlexLibrary', psCron);
+            logger.info(`Plex library sync schedule updated: ${psCron}`);
+          }
         }
       } catch (error) {
         logger.error('Failed to update scheduler:', error);

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -118,7 +118,7 @@ router.get('/', (_req: Request, res: Response) => {
         const field = key.replace('schedule_', '');
         if (value === 'true' || value === 'false') {
           schedule[field] = value === 'true';
-        } else if (!isNaN(Number(value)) && field !== 'time') {
+        } else if (value !== '' && !isNaN(Number(value)) && field !== 'time') {
           schedule[field] = Number(value);
         } else {
           schedule[field] = value;
@@ -131,7 +131,7 @@ router.get('/', (_req: Request, res: Response) => {
         const field = key.replace('plexSync_', '');
         if (value === 'true' || value === 'false') {
           plexSync[field] = value === 'true';
-        } else if (!isNaN(Number(value)) && field !== 'time') {
+        } else if (value !== '' && !isNaN(Number(value)) && field !== 'time') {
           plexSync[field] = Number(value);
         } else {
           plexSync[field] = value;

--- a/server/src/scheduler/index.ts
+++ b/server/src/scheduler/index.ts
@@ -7,6 +7,7 @@ import {
   sendDeletionReminders,
   captureStorageSnapshot,
   syncPlexUsers,
+  syncPlexLibrary,
   getTask,
   getAvailableTasks,
   type TaskResult,
@@ -20,6 +21,7 @@ import {
 export interface SchedulerConfig {
   enabledTasks: string[];
   schedules: {
+    syncPlexLibrary: string;
     scanLibraries: string;
     processDeletionQueue: string;
     sendDeletionReminders: string;
@@ -30,8 +32,9 @@ export interface SchedulerConfig {
 }
 
 const DEFAULT_CONFIG: SchedulerConfig = {
-  enabledTasks: ['scanLibraries', 'processDeletionQueue', 'sendDeletionReminders', 'captureStorageSnapshot', 'syncPlexUsers'],
+  enabledTasks: ['syncPlexLibrary', 'scanLibraries', 'processDeletionQueue', 'sendDeletionReminders', 'captureStorageSnapshot', 'syncPlexUsers'],
   schedules: {
+    syncPlexLibrary: '0 2 * * *', // Daily at 2 AM (before scan, so rules see fresh catalog)
     scanLibraries: '0 3 * * *', // Daily at 3 AM
     processDeletionQueue: '0 4 * * *', // Daily at 4 AM
     sendDeletionReminders: '0 9 * * *', // Daily at 9 AM
@@ -97,6 +100,11 @@ export class Scheduler {
     }
 
     logger.info('Starting scheduler');
+
+    // Schedule Plex library sync (runs first; pulls catalog into DB)
+    if (this.config.enabledTasks.includes('syncPlexLibrary')) {
+      this.scheduleJob('syncPlexLibrary', this.config.schedules.syncPlexLibrary, syncPlexLibrary);
+    }
 
     // Schedule library scans
     if (this.config.enabledTasks.includes('scanLibraries')) {

--- a/server/src/scheduler/tasks.ts
+++ b/server/src/scheduler/tasks.ts
@@ -5,7 +5,7 @@ import storageSnapshotsRepo from '../db/repositories/storageSnapshots';
 import settingsRepo from '../db/repositories/settings';
 import { getDeletionService } from '../services/deletion';
 import { PlexUsersService } from '../services/plexUsers';
-import { runLibrarySync } from '../services/syncCoordinator';
+import { isSyncInProgress, runLibrarySync } from '../services/syncCoordinator';
 import { logActivity } from '../db/repositories/activity';
 import collectionsRepo from '../db/repositories/collections';
 import { evaluateRuleConditions } from '../rules/engine';
@@ -981,27 +981,15 @@ export async function syncPlexLibrary(): Promise<TaskResult> {
 
   logger.info('Starting scheduled Plex library sync');
 
-  try {
-    logActivity({
-      eventType: 'scan',
-      action: 'started',
-      actorType: 'scheduler',
-      actorId: 'system',
-      actorName: 'Scheduled Plex Sync',
-      targetType: null,
-      targetId: null,
-      targetTitle: null,
-      metadata: null,
-    });
-  } catch (activityError) {
-    logger.warn('Failed to log Plex sync start activity:', activityError);
-  }
-
-  const outcome = await runLibrarySync();
-  const completedAt = new Date();
-  const durationMs = completedAt.getTime() - startedAt.getTime();
-
-  if (outcome.status === 'busy') {
+  // Early-exit if another sync is already running so we don't write an orphan
+  // 'started' activity entry that never gets a matching 'completed'. The
+  // isSyncInProgress() check and the runLibrarySync() call below are both
+  // synchronous in JS's single-threaded loop, so the coordinator's internal
+  // 'busy' guard is only reached if we somehow miss here — handled below
+  // as a defensive fallback.
+  if (isSyncInProgress()) {
+    const completedAt = new Date();
+    const durationMs = completedAt.getTime() - startedAt.getTime();
     logger.warn('Scheduled Plex sync skipped: another sync is already running');
     try {
       logActivity({
@@ -1025,6 +1013,55 @@ export async function syncPlexLibrary(): Promise<TaskResult> {
       completedAt,
       durationMs,
       message: 'Skipped — another sync was already running',
+      data: { skipped: true },
+    };
+  }
+
+  try {
+    logActivity({
+      eventType: 'scan',
+      action: 'started',
+      actorType: 'scheduler',
+      actorId: 'system',
+      actorName: 'Scheduled Plex Sync',
+      targetType: null,
+      targetId: null,
+      targetTitle: null,
+      metadata: null,
+    });
+  } catch (activityError) {
+    logger.warn('Failed to log Plex sync start activity:', activityError);
+  }
+
+  const outcome = await runLibrarySync();
+  const completedAt = new Date();
+  const durationMs = completedAt.getTime() - startedAt.getTime();
+
+  // Defensive: a coordinator-level 'busy' should be impossible here given the
+  // pre-check, but handle it anyway so the run is still represented in the log.
+  if (outcome.status === 'busy') {
+    try {
+      logActivity({
+        eventType: 'scan',
+        action: 'skipped',
+        actorType: 'scheduler',
+        actorId: 'system',
+        actorName: 'Scheduled Plex Sync',
+        targetType: null,
+        targetId: null,
+        targetTitle: null,
+        metadata: JSON.stringify({ reason: 'coordinator reported busy after pre-check' }),
+      });
+    } catch (activityError) {
+      logger.warn('Failed to log Plex sync skipped activity:', activityError);
+    }
+    return {
+      success: true,
+      taskName,
+      startedAt,
+      completedAt,
+      durationMs,
+      message: 'Skipped — coordinator reported busy',
       data: { skipped: true },
     };
   }

--- a/server/src/scheduler/tasks.ts
+++ b/server/src/scheduler/tasks.ts
@@ -5,6 +5,7 @@ import storageSnapshotsRepo from '../db/repositories/storageSnapshots';
 import settingsRepo from '../db/repositories/settings';
 import { getDeletionService } from '../services/deletion';
 import { PlexUsersService } from '../services/plexUsers';
+import { runLibrarySync } from '../services/syncCoordinator';
 import { logActivity } from '../db/repositories/activity';
 import collectionsRepo from '../db/repositories/collections';
 import { evaluateRuleConditions } from '../rules/engine';
@@ -965,12 +966,150 @@ export async function syncPlexUsers(): Promise<TaskResult> {
 }
 
 // ============================================================================
+// Plex Library Sync Task
+// ============================================================================
+
+/**
+ * Pull the catalog from Plex into the local DB on a schedule, so users don't
+ * have to click "Sync Library" manually to pick up new movies/shows. Shares
+ * the syncCoordinator's in-progress flag with the manual button so the two
+ * can never run at the same time.
+ */
+export async function syncPlexLibrary(): Promise<TaskResult> {
+  const startedAt = new Date();
+  const taskName = 'syncPlexLibrary';
+
+  logger.info('Starting scheduled Plex library sync');
+
+  try {
+    logActivity({
+      eventType: 'scan',
+      action: 'started',
+      actorType: 'scheduler',
+      actorId: 'system',
+      actorName: 'Scheduled Plex Sync',
+      targetType: null,
+      targetId: null,
+      targetTitle: null,
+      metadata: null,
+    });
+  } catch (activityError) {
+    logger.warn('Failed to log Plex sync start activity:', activityError);
+  }
+
+  const outcome = await runLibrarySync();
+  const completedAt = new Date();
+  const durationMs = completedAt.getTime() - startedAt.getTime();
+
+  if (outcome.status === 'busy') {
+    logger.warn('Scheduled Plex sync skipped: another sync is already running');
+    try {
+      logActivity({
+        eventType: 'scan',
+        action: 'skipped',
+        actorType: 'scheduler',
+        actorId: 'system',
+        actorName: 'Scheduled Plex Sync',
+        targetType: null,
+        targetId: null,
+        targetTitle: null,
+        metadata: JSON.stringify({ reason: 'another sync is already running' }),
+      });
+    } catch (activityError) {
+      logger.warn('Failed to log Plex sync skipped activity:', activityError);
+    }
+    return {
+      success: true,
+      taskName,
+      startedAt,
+      completedAt,
+      durationMs,
+      message: 'Skipped — another sync was already running',
+      data: { skipped: true },
+    };
+  }
+
+  if (outcome.status === 'failed') {
+    try {
+      logActivity({
+        eventType: 'scan',
+        action: 'failed',
+        actorType: 'scheduler',
+        actorId: 'system',
+        actorName: 'Scheduled Plex Sync',
+        targetType: null,
+        targetId: null,
+        targetTitle: null,
+        metadata: JSON.stringify({ error: outcome.error, duration: durationMs }),
+      });
+    } catch (activityError) {
+      logger.warn('Failed to log Plex sync failure activity:', activityError);
+    }
+
+    return {
+      success: false,
+      taskName,
+      startedAt,
+      completedAt,
+      durationMs,
+      error: outcome.error,
+    };
+  }
+
+  const result = outcome.result!;
+  const errorCount = result.errors.length;
+
+  try {
+    logActivity({
+      eventType: 'scan',
+      action: 'completed',
+      actorType: 'scheduler',
+      actorId: 'system',
+      actorName: 'Scheduled Plex Sync',
+      targetType: null,
+      targetId: null,
+      targetTitle: null,
+      metadata: JSON.stringify({
+        itemsScanned: result.itemsScanned,
+        itemsAdded: result.itemsAdded,
+        itemsUpdated: result.itemsUpdated,
+        errors: errorCount,
+        duration: durationMs,
+      }),
+    });
+  } catch (activityError) {
+    logger.warn('Failed to log Plex sync completion activity:', activityError);
+  }
+
+  logger.info(
+    `Scheduled Plex sync completed: ${result.itemsScanned} scanned, ` +
+      `${result.itemsAdded} added, ${result.itemsUpdated} updated, ${errorCount} errors (${durationMs}ms)`
+  );
+
+  return {
+    success: errorCount === 0,
+    taskName,
+    startedAt,
+    completedAt,
+    durationMs,
+    message: `Synced ${result.itemsScanned} items from Plex`,
+    data: {
+      itemsScanned: result.itemsScanned,
+      itemsAdded: result.itemsAdded,
+      itemsUpdated: result.itemsUpdated,
+      errors: errorCount,
+    },
+  };
+}
+
+// ============================================================================
 // Task Registry
 // ============================================================================
 
 export type TaskFunction = () => Promise<TaskResult>;
 
 export const taskRegistry: Record<string, TaskFunction> = {
+  syncPlexLibrary,
   scanLibraries,
   processDeletionQueue,
   sendDeletionReminders,

--- a/server/src/services/init.ts
+++ b/server/src/services/init.ts
@@ -365,6 +365,46 @@ function initializeSchedulerFromSettings(): void {
       scheduler.enableTask('processDeletionQueue');
       logger.info('Auto-process deletion queue is enabled (per saved settings)');
     }
+
+    // Handle syncPlexLibrary task — hydrate from plexSync_* settings so the
+    // schedule survives restarts. Missing settings fall through to the default
+    // ('0 2 * * *' from DEFAULT_CONFIG), which leaves the task running daily
+    // at 2 AM as designed.
+    const psEnabled = settingsRepo.getValue('plexSync_enabled');
+    const psInterval = settingsRepo.getValue('plexSync_interval');
+    const psTime = settingsRepo.getValue('plexSync_time');
+    const psDayOfWeek = settingsRepo.getValue('plexSync_dayOfWeek');
+
+    if (psEnabled === 'false') {
+      scheduler.disableTask('syncPlexLibrary');
+      logger.info('Scheduled Plex library sync is disabled (per saved settings)');
+    } else if (psInterval || psTime || psDayOfWeek) {
+      // Only rebuild the cron expression if the user has saved something —
+      // otherwise the DEFAULT_CONFIG schedule applies.
+      const effInterval = psInterval || 'daily';
+      const effTime = psTime || '02:00';
+      const [psHour, psMinute] = effTime.split(':').map(Number);
+
+      let psCron: string;
+      switch (effInterval) {
+        case 'hourly':
+          psCron = `${psMinute} * * * *`;
+          break;
+        case 'weekly':
+          psCron = `${psMinute} ${psHour} * * ${psDayOfWeek ?? 0}`;
+          break;
+        case 'daily':
+        default:
+          psCron = `${psMinute} ${psHour} * * *`;
+          break;
+      }
+
+      scheduler.updateSchedule('syncPlexLibrary', psCron);
+      if (psEnabled === 'true') {
+        scheduler.enableTask('syncPlexLibrary');
+      }
+      logger.info(`Plex sync schedule initialized from settings: ${effInterval} at ${effTime} (cron: ${psCron})`);
+    }
   } catch (error) {
     logger.error('Failed to initialize scheduler from settings:', error);
     // Fall back to default schedule - don't fail startup

--- a/server/src/services/syncCoordinator.ts
+++ b/server/src/services/syncCoordinator.ts
@@ -1,0 +1,110 @@
+import mediaItemsRepo from '../db/repositories/mediaItems';
+import logger from '../utils/logger';
+import { ScannerService } from './scanner';
+import type { ScanResult, SyncProgressCallback } from './types';
+
+// Shared singleton so the manual button (routes/library.ts) and the scheduled
+// task (scheduler/tasks.ts:syncPlexLibrary) cannot run two Plex pulls at once,
+// and so the UI can show "Last synced" timestamps regardless of which path
+// completed the run.
+
+let scannerService: ScannerService | null = null;
+let syncInProgress = false;
+let lastSyncCompletedAt: Date | null = null;
+
+const syncProgressLog: unknown[] = [];
+type SyncListener = (data: unknown) => void;
+const syncListeners = new Set<SyncListener>();
+
+function getScanner(): ScannerService {
+  if (!scannerService) {
+    scannerService = new ScannerService();
+    scannerService.setDatabaseCallback(async (items) => {
+      for (const item of items) {
+        const input = scannerService!.convertToMediaItemInput(item);
+        const existingItem = input.plex_id ? mediaItemsRepo.getByPlexId(input.plex_id) : null;
+        if (existingItem) {
+          // Strip status so a sync never clobbers queue/protection state.
+          const { status: _status, ...plexFields } = input;
+          mediaItemsRepo.update(existingItem.id, plexFields);
+        } else {
+          mediaItemsRepo.create(input);
+        }
+      }
+    });
+  }
+  return scannerService;
+}
+
+export function isSyncInProgress(): boolean {
+  return syncInProgress;
+}
+
+export function getLastSyncCompletedAt(): Date | null {
+  return lastSyncCompletedAt;
+}
+
+export function getSyncProgressLog(): unknown[] {
+  return [...syncProgressLog];
+}
+
+export function subscribeToSync(listener: SyncListener): () => void {
+  syncListeners.add(listener);
+  return () => syncListeners.delete(listener);
+}
+
+function broadcastProgress(data: unknown): void {
+  syncProgressLog.push(data);
+  for (const listener of syncListeners) {
+    try { listener(data); } catch { /* client disconnected */ }
+  }
+}
+
+export interface RunSyncResult {
+  status: 'completed' | 'busy' | 'failed';
+  result?: ScanResult;
+  error?: string;
+}
+
+/**
+ * Run a full Plex → DB sync. Returns 'busy' immediately if another sync is
+ * already running (either manual or scheduled) so callers don't double-fire.
+ * onProgress is invoked alongside the shared broadcast channel.
+ */
+export async function runLibrarySync(onProgress?: SyncProgressCallback): Promise<RunSyncResult> {
+  if (syncInProgress) {
+    return { status: 'busy' };
+  }
+
+  syncInProgress = true;
+  syncProgressLog.length = 0;
+
+  try {
+    const scanner = getScanner();
+    scanner.reinitialize();
+
+    const result = await scanner.scanAll((progress) => {
+      broadcastProgress(progress);
+      onProgress?.(progress);
+    });
+
+    lastSyncCompletedAt = new Date();
+    return { status: 'completed', result };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('Library sync failed:', error);
+    broadcastProgress({
+      stage: 'error',
+      message: `Sync failed: ${message}`,
+      result: { success: false, itemsScanned: 0, itemsAdded: 0, itemsUpdated: 0, errors: 1 },
+    });
+    return { status: 'failed', error: message };
+  } finally {
+    syncInProgress = false;
+    // Tell streaming clients the run is over so they can close.
+    for (const listener of syncListeners) {
+      try { listener({ stage: 'complete', message: 'Sync stream ended' }); } catch { /* ignore */ }
+    }
+    syncListeners.clear();
+  }
+}

--- a/server/src/services/syncCoordinator.ts
+++ b/server/src/services/syncCoordinator.ts
@@ -11,6 +11,8 @@ import type { ScanResult, SyncProgressCallback } from './types';
 let scannerService: ScannerService | null = null;
 let syncInProgress = false;
 let lastSyncCompletedAt: Date | null = null;
+let lastSyncFinishedAt: Date | null = null;
+let lastSyncSuccess: boolean | null = null;
 
 const syncProgressLog: unknown[] = [];
 type SyncListener = (data: unknown) => void;
@@ -42,6 +44,14 @@ export function isSyncInProgress(): boolean {
 
 export function getLastSyncCompletedAt(): Date | null {
   return lastSyncCompletedAt;
+}
+
+export function getLastSyncFinishedAt(): Date | null {
+  return lastSyncFinishedAt;
+}
+
+export function getLastSyncSuccess(): boolean | null {
+  return lastSyncSuccess;
 }
 
 export function getSyncProgressLog(): unknown[] {
@@ -88,7 +98,10 @@ export async function runLibrarySync(onProgress?: SyncProgressCallback): Promise
       onProgress?.(progress);
     });
 
-    lastSyncCompletedAt = new Date();
+    const now = new Date();
+    lastSyncCompletedAt = now;
+    lastSyncFinishedAt = now;
+    lastSyncSuccess = true;
     return { status: 'completed', result };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -98,6 +111,8 @@ export async function runLibrarySync(onProgress?: SyncProgressCallback): Promise
       message: `Sync failed: ${message}`,
       result: { success: false, itemsScanned: 0, itemsAdded: 0, itemsUpdated: 0, errors: 1 },
     });
+    lastSyncFinishedAt = new Date();
+    lastSyncSuccess = false;
     return { status: 'failed', error: message };
   } finally {
     syncInProgress = false;


### PR DESCRIPTION
Adds a new `syncPlexLibrary` scheduled task that runs `scanner.scanAll()` on
a configurable cron (default 2 AM daily), so new movies/shows in Plex appear
in Prunerr without users having to click the manual "Sync Library" button.

- syncCoordinator owns the shared in-progress flag, last-sync timestamp, and
  scanner singleton so the manual button and the scheduled task can never run
  scanner.scanAll() at the same time.
- Settings exposes a "Plex Library Sync" card mirroring the existing Scan
  Schedule card, with the same interval/time/day-of-week controls. PUT and
  startup hydration both reconfigure the scheduled task from saved plexSync_*
  keys, so the schedule survives restarts.
- Activity log gets started/completed/failed/skipped entries with
  actorName="Scheduled Plex Sync".
- /api/health/status now also returns lastSync/nextSync/syncSchedule.

Closes the gap reported in #24.