### PR TITLE
Fix queue endpoint to return full queue when limit is omitted

### DIFF
--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -188,7 +188,11 @@ router.get('/upcoming', (req: Request, res: Response) => {
 // GET /api/queue - Get full deletion queue
 router.get('/', (req: Request, res: Response) => {
   try {
-    const limit = parseInt(req.query['limit'] as string, 10) || 100;
+    // `limit` is optional. When omitted (or non-positive) the entire queue is
+    // returned — the Queue page renders every item and paginates client-side,
+    // so a default cap here would silently hide items.
+    const limitParam = parseInt(req.query['limit'] as string, 10);
+    const hasLimit = !Number.isNaN(limitParam) && limitParam > 0;
     const offset = parseInt(req.query['offset'] as string, 10) || 0;
 
     // Get all items pending deletion
@@ -228,7 +232,9 @@ router.get('/', (req: Request, res: Response) => {
       })
       .sort((a, b) => a.daysRemaining - b.daysRemaining);
 
-    const paginatedItems = allQueueItems.slice(offset, offset + limit);
+    const paginatedItems = hasLimit
+      ? allQueueItems.slice(offset, offset + limitParam)
+      : allQueueItems.slice(offset);
 
     // Calculate totals
     const totalSize = allQueueItems.reduce((sum, item) => sum + item.size, 0);
@@ -239,7 +245,7 @@ router.get('/', (req: Request, res: Response) => {
       success: true,
       data: paginatedItems,
       total: allQueueItems.length,
-      limit,
+      limit: hasLimit ? limitParam : allQueueItems.length,
       offset,
       summary: {
         totalItems: allQueueItems.length,


### PR DESCRIPTION
## Summary
Modified the `/api/queue` GET endpoint to properly handle cases where the `limit` query parameter is omitted or invalid. Previously, a default limit of 100 was always applied, which could silently hide queue items. Now, when `limit` is omitted or non-positive, the entire queue is returned.

## Changes
- Changed `limit` parameter handling from a default fallback (`|| 100`) to explicit validation
- Added `hasLimit` flag to distinguish between "limit provided and valid" vs "no limit specified"
- Updated pagination logic to return the full queue (with offset applied) when no limit is specified
- Updated the response's `limit` field to reflect the actual limit applied (either the parsed value or the total queue length)

## Implementation Details
- The Queue page renders all items and handles pagination client-side, so a server-side cap would silently hide items from users
- The `limit` parameter is now truly optional: only positive integers are treated as valid limits
- Non-positive or unparseable limit values result in returning the entire queue (minus the offset)
- The response accurately reports what limit was applied via the `limit` field

https://claude.ai/code/session_01L5ZGspmjesdQ2xCYAM5Qoz