### PR TITLE
Add support for filtering media by Overseerr/Jellyseerr requester

### DIFF
--- a/client/src/components/Rules/ConditionEditor.tsx
+++ b/client/src/components/Rules/ConditionEditor.tsx
@@ -10,6 +10,7 @@ import {
   Star,
   Eye,
   Tag,
+  Inbox,
 } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { collectionsApi, usersApi } from '@/services/api';
@@ -639,6 +640,7 @@ const GROUP_ICONS: Record<string, React.ElementType> = {
   eye: Eye,
   layers: Layers,
   tag: Tag,
+  inbox: Inbox,
 };
 
 function FieldPicker({

--- a/client/src/components/Rules/FieldCatalog.ts
+++ b/client/src/components/Rules/FieldCatalog.ts
@@ -23,7 +23,8 @@ export type FieldGroup =
   | 'ratings'
   | 'watching'
   | 'collections'
-  | 'metadata';
+  | 'metadata'
+  | 'requests';
 
 export type Operator =
   // numeric + equality
@@ -430,6 +431,18 @@ export const FIELD_CATALOG: FieldDef[] = [
     defaultOperator: 'equals',
     defaultValue: 'en',
   },
+
+  // ────────────── Requests ──────────────
+  {
+    id: 'requested_by',
+    label: 'Requested by',
+    group: 'requests',
+    valueType: 'string',
+    operators: STRING_OPS,
+    defaultOperator: 'equals',
+    placeholder: 'Username',
+    defaultValue: '',
+  },
 ];
 
 export const FIELD_GROUPS: Array<{
@@ -445,6 +458,7 @@ export const FIELD_GROUPS: Array<{
   { id: 'watching', label: 'Watching', icon: 'eye', description: 'Per-user watch status' },
   { id: 'collections', label: 'Collections', icon: 'layers', description: 'Collection membership' },
   { id: 'metadata', label: 'Metadata', icon: 'tag', description: 'Genres, tags, studio, etc.' },
+  { id: 'requests', label: 'Requests', icon: 'inbox', description: 'Overseerr / Jellyseerr requests' },
 ];
 
 const FIELD_BY_ID: Record<string, FieldDef> = FIELD_CATALOG.reduce(

--- a/server/src/db/repositories/mediaItems.ts
+++ b/server/src/db/repositories/mediaItems.ts
@@ -56,6 +56,7 @@ interface MediaItemRow {
   rating_rt: number | null;
   content_rating: string | null;
   original_language: string | null;
+  requested_by: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -222,8 +223,9 @@ export function createMediaItem(input: CreateMediaItemInput): MediaItem {
       genres, tags, studio, audio_codec, video_codec, hdr, bitrate,
       runtime_minutes, season_count, episode_count, series_status,
       rating_imdb, rating_tmdb, rating_rt, content_rating, original_language,
+      requested_by,
       created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const result = stmt.run(
@@ -263,6 +265,7 @@ export function createMediaItem(input: CreateMediaItemInput): MediaItem {
     input.rating_rt ?? null,
     input.content_rating ?? null,
     input.original_language ?? null,
+    input.requested_by ?? null,
     now,
     now
   );
@@ -459,6 +462,10 @@ export function updateMediaItem(id: number, input: UpdateMediaItemInput): MediaI
   if (input.original_language !== undefined) {
     updates.push('original_language = ?');
     params.push(input.original_language);
+  }
+  if (input.requested_by !== undefined) {
+    updates.push('requested_by = ?');
+    params.push(input.requested_by);
   }
 
   if (updates.length === 0) {

--- a/server/src/services/scanner.ts
+++ b/server/src/services/scanner.ts
@@ -714,7 +714,7 @@ export class ScannerService {
    * Convert synced data to database input format
    */
   convertToMediaItemInput(syncedData: SyncedMediaData): CreateMediaItemInput {
-    const { plexItem, tautulliData, arrData, libraryKey } = syncedData;
+    const { plexItem, tautulliData, arrData, libraryKey, overseerrData } = syncedData;
 
     // Determine type
     let type: MediaType = 'movie';
@@ -912,6 +912,9 @@ export class ScannerService {
       rating_rt: ratingRt,
       content_rating: contentRating,
       original_language: originalLanguage,
+      // Only overwrite requested_by when Overseerr was actually queried for
+      // this item; otherwise leave any existing value untouched on re-sync.
+      requested_by: overseerrData ? overseerrData.requestedBy : undefined,
     };
   }
 

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -66,6 +66,8 @@ export interface MediaItem {
   rating_rt: number | null;
   content_rating: string | null;
   original_language: string | null;
+  // Who requested this content (from Overseerr / Jellyseerr)
+  requested_by: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -166,6 +168,7 @@ export interface CreateMediaItemInput {
   rating_rt?: number;
   content_rating?: string;
   original_language?: string;
+  requested_by?: string | null;
 }
 
 export interface UpdateMediaItemInput {
@@ -213,6 +216,7 @@ export interface UpdateMediaItemInput {
   rating_rt?: number;
   content_rating?: string;
   original_language?: string;
+  requested_by?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a new "Requests" field group that allows users to filter media items based on who requested them via Overseerr or Jellyseerr. This enables library managers to identify and manage content based on request origin.

## Key Changes
- **Client**: Added new `requests` field group to the Rules UI with a "Requested by" field that filters by username
  - New field: `requested_by` (string type, supports equality operators)
  - New field group with inbox icon and description
  - Updated icon mapping in ConditionEditor
  
- **Server**: Extended media item schema to track request origin
  - Added `requested_by` column to MediaItem type and database schema
  - Updated `CreateMediaItemInput` and `UpdateMediaItemInput` interfaces
  - Modified scanner to populate `requested_by` from Overseerr data when available
  
- **Scanner**: Integrated Overseerr data into media item conversion
  - Extracts `requestedBy` from Overseerr sync data
  - Only overwrites existing `requested_by` value when Overseerr data is present, preserving values on re-sync

## Implementation Details
- The `requested_by` field is nullable to support media items that weren't requested through Overseerr/Jellyseerr
- Scanner logic preserves existing `requested_by` values during re-sync if Overseerr data isn't available, preventing data loss
- Field uses standard string operators (equals, contains, etc.) for flexible filtering

https://claude.ai/code/session_01KvF7ygLVjHgpnAnwc9qxJY