### PR TITLE
fix: repair server build + add requester dropdown to rule builder

### DIFF
--- a/server/src/rules/__tests__/evaluateNode.test.ts
+++ b/server/src/rules/__tests__/evaluateNode.test.ts
@@ -46,6 +46,7 @@ function makeItem(overrides: Partial<MediaItem> = {}): MediaItem {
     rating_rt: 85,
     content_rating: 'R',
     original_language: 'en',
+    requested_by: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,

--- a/server/src/rules/__tests__/regression.test.ts
+++ b/server/src/rules/__tests__/regression.test.ts
@@ -47,6 +47,7 @@ function item(overrides: Partial<MediaItem> = {}): MediaItem {
     rating_rt: null,
     content_rating: null,
     original_language: null,
+    requested_by: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,


### PR DESCRIPTION
## Summary

Two related changes for the "Requested by" rule feature added in #30:

### 1. Build fix (commit 1)

#30 made `requested_by` a required field on `MediaItem`, which broke the server build (`npm run build` / `tsc`). The fix landed on the feature branch *after* #30 was already merged, so it never reached `main` — the Docker image build has been failing since.

The `makeItem` / `item` test helpers build a `MediaItem` by spreading `...overrides: Partial<MediaItem>` over an object literal that omitted `requested_by`, widening the property to `string | null | undefined`. Fixed by adding `requested_by: null` to both fixtures.

### 2. Requester dropdown (commit 2)

The "Requested by" rule field was a plain free-text input. This adds a searchable dropdown:

- **Server**: new `GET /api/media/requesters` endpoint returning the distinct `requested_by` values present in the library.
- **Client**: `requested_by` now renders a combobox (`RequesterWidget`) populated from that endpoint. It mirrors the existing "Watched by user" picker — same styling and type-to-filter / select-or-free-type behavior. Free-typing is still allowed for usernames not yet seen in a scan.

## Verification

- `npm run build` (server): passes
- `npm run build` (client): passes
- Server tests: 45/45 passing

After merging, push a new `v*` tag (or run the workflow via `workflow_dispatch`) to trigger a fresh Docker build — re-running the old failed run will not pick up these commits.

https://claude.ai/code/session_01KvF7ygLVjHgpnAnwc9qxJY