### PR TITLE
fix: actually ship requester dropdown + add Overseerr sync logging

### DIFF
--- a/client/src/components/Rules/ConditionEditor.tsx
+++ b/client/src/components/Rules/ConditionEditor.tsx
@@ -13,7 +13,7 @@ import {
   Inbox,
 } from 'lucide-react';
 import { Button } from '@/components/common/Button';
-import { collectionsApi, usersApi } from '@/services/api';
+import { collectionsApi, usersApi, requestersApi } from '@/services/api';
 import type { ConditionGroupNode, ConditionLeaf, ConditionNode, GroupLogic } from '@/types';
 import {
   FIELD_CATALOG,
@@ -374,6 +374,8 @@ function ValueWidget({
           onChange={onChange}
         />
       );
+    case 'requester':
+      return <RequesterWidget value={value} onChange={onChange} />;
     default:
       return null;
   }
@@ -606,6 +608,95 @@ function CollectionWidget({
         </option>
       ))}
     </select>
+  );
+}
+
+function RequesterWidget({
+  value,
+  onChange,
+}: {
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  const current = String(value ?? '');
+  const { data: requesters = [] } = useQuery({
+    queryKey: ['requesters'],
+    queryFn: requestersApi.list,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const [search, setSearch] = useState(current);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Keep the input in sync when the condition value changes elsewhere.
+  useEffect(() => { setSearch(current); }, [current]);
+
+  // Close on click outside, committing any free-typed text.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        if (search !== current) onChange(search);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open, search, current, onChange]);
+
+  const matches = requesters.filter((r) =>
+    r.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div ref={ref} className="relative">
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => { setSearch(e.target.value); setOpen(true); }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            onChange(search);
+            setOpen(false);
+          } else if (e.key === 'Escape') {
+            setOpen(false);
+          }
+        }}
+        placeholder="Type or select requester…"
+        className={`${baseInputClass} min-w-[140px] sm:min-w-[180px]`}
+      />
+      {open && (
+        <div className="absolute top-full left-0 mt-1 z-50 w-full max-h-48 overflow-y-auto bg-surface-800 border border-surface-600 rounded-lg shadow-xl shadow-black/15">
+          {matches.length > 0 ? (
+            matches.map((r) => (
+              <button
+                key={r}
+                type="button"
+                onClick={() => { setSearch(r); onChange(r); setOpen(false); }}
+                className={`w-full px-3 py-2 text-sm text-left transition-colors ${
+                  r === current
+                    ? 'bg-accent-500/15 text-accent-300'
+                    : 'text-surface-200 hover:bg-surface-700/60'
+                }`}
+              >
+                {r}
+              </button>
+            ))
+          ) : requesters.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-surface-500">
+              No requester data yet — run a library sync with Overseerr/Jellyseerr connected.
+            </div>
+          ) : (
+            <div className="px-3 py-2 text-xs text-surface-500">
+              No matches — press Enter to use "{search}"
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/client/src/components/Rules/FieldCatalog.ts
+++ b/client/src/components/Rules/FieldCatalog.ts
@@ -15,7 +15,8 @@ export type ValueType =
   | 'list'
   | 'date'
   | 'user'
-  | 'collection';
+  | 'collection'
+  | 'requester';
 
 export type FieldGroup =
   | 'basics'
@@ -437,7 +438,7 @@ export const FIELD_CATALOG: FieldDef[] = [
     id: 'requested_by',
     label: 'Requested by',
     group: 'requests',
-    valueType: 'string',
+    valueType: 'requester',
     operators: STRING_OPS,
     defaultOperator: 'equals',
     placeholder: 'Username',

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -394,6 +394,13 @@ export const usersApi = {
   },
 };
 
+export const requestersApi = {
+  list: async (): Promise<string[]> => {
+    const { data } = await api.get<ApiResponse<string[]>>('/media/requesters');
+    return data.data || [];
+  },
+};
+
 // Queue APIs
 export const queueApi = {
   getAll: async (): Promise<QueueItem[]> => {

--- a/server/src/db/repositories/mediaItems.ts
+++ b/server/src/db/repositories/mediaItems.ts
@@ -644,6 +644,16 @@ export function getMediaStats(): { total: number; byType: Record<string, number>
   return { total, byType, byStatus, totalSize, totalEpisodes };
 }
 
+export function getDistinctRequesters(): string[] {
+  const db = getDatabase();
+  const stmt = db.prepare<[], { requested_by: string }>(
+    `SELECT DISTINCT requested_by FROM media_items
+     WHERE requested_by IS NOT NULL AND requested_by != ''
+     ORDER BY requested_by COLLATE NOCASE`
+  );
+  return stmt.all().map((row) => row.requested_by);
+}
+
 export default {
   getAll: getAllMediaItems,
   getById: getMediaItemById,
@@ -666,4 +676,5 @@ export default {
   getOlderThan: getMediaItemsOlderThan,
   getUnwatched: getUnwatchedMediaItems,
   getStats: getMediaStats,
+  getDistinctRequesters,
 };

--- a/server/src/routes/media.ts
+++ b/server/src/routes/media.ts
@@ -133,6 +133,23 @@ router.get('/pending', (_req: Request, res: Response) => {
   }
 });
 
+// GET /api/media/requesters - Distinct Overseerr/Jellyseerr requester names
+router.get('/requesters', (_req: Request, res: Response) => {
+  try {
+    const requesters = mediaItemsRepo.getDistinctRequesters();
+    res.json({
+      success: true,
+      data: requesters,
+    });
+  } catch (error) {
+    logger.error('Failed to get requesters:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to retrieve requesters',
+    });
+  }
+});
+
 // GET /api/media/:id - Get a specific media item
 router.get('/:id', (req: Request, res: Response) => {
   try {

--- a/server/src/services/scanner.ts
+++ b/server/src/services/scanner.ts
@@ -59,6 +59,10 @@ export class ScannerService {
   // Database callback - to be injected
   private dbCallback: ((items: SyncedMediaData[]) => Promise<void>) | null = null;
 
+  // Set once per scan after the first failed Overseerr lookup, so a systemic
+  // failure (bad URL/key) is logged once instead of per item.
+  private overseerrErrorLogged = false;
+
   constructor() {
     this.initializeServices();
   }
@@ -139,6 +143,7 @@ export class ScannerService {
     this.sonarr = null;
     this.radarr = null;
     this.overseerr = null;
+    this.overseerrErrorLogged = false;
     this.clearCaches();
     this.initializeServices();
 
@@ -236,6 +241,11 @@ export class ScannerService {
       }
 
       logger.info(`Found ${mediaLibraries.length} media libraries to scan`);
+      logger.info(
+        this.overseerr
+          ? 'Overseerr connected — will resolve "Requested by" for items matched to Sonarr/Radarr'
+          : 'Overseerr not configured — "Requested by" data will not be collected this scan'
+      );
       onProgress?.({
         stage: 'scanning_library',
         message: `Found ${mediaLibraries.length} libraries to scan`,
@@ -419,6 +429,19 @@ export class ScannerService {
       }
     }
 
+    if (this.overseerr) {
+      const arrMatched = syncedItems.filter((s) => s.arrData).length;
+      const requesters = syncedItems
+        .map((s) => s.overseerrData?.requestedBy)
+        .filter((r): r is string => Boolean(r));
+      const distinctRequesters = new Set(requesters);
+      logger.info(
+        `Overseerr requesters in "${library.title}": ${requesters.length} of ${itemsScanned} items ` +
+          `have a requester across ${distinctRequesters.size} user(s); ` +
+          `${arrMatched} of ${itemsScanned} matched to Sonarr/Radarr`
+      );
+    }
+
     logger.info(`Completed scanning library: ${library.title}`, {
       itemsScanned,
       errors: errors.length,
@@ -485,8 +508,16 @@ export class ScannerService {
           const requestedBy = await this.overseerr.getRequestedBy(guids.tmdbId, 'tv');
           overseerrData = { requestedBy, request: null };
         }
-      } catch {
-        // Continue without Overseerr data
+      } catch (error) {
+        // Continue without Overseerr data, but surface the first failure so a
+        // systemic problem (unreachable Overseerr, bad API key) is visible.
+        if (!this.overseerrErrorLogged) {
+          this.overseerrErrorLogged = true;
+          logger.warn(
+            `Overseerr requester lookup failed for "${fullItem.title}" — `
+              + `requester data may be incomplete: ${(error as Error).message}`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Why this PR exists

The "Requested by" searchable dropdown **never actually reached `main`**. It was developed on the PR #31 branch, but PR #31 was merged with only its build-fix commit — the dropdown commit landed on the branch afterward and was left behind. So `v1.4.13` shipped the rule field as a plain text input, which is why the dropdown still doesn't appear.

This PR brings the dropdown to `main` for real, plus new sync logging.

## Changes

### Requester dropdown (was missing from v1.4.13)
- **Server**: `GET /api/media/requesters` returns the distinct `requested_by` values present in the library.
- **Client**: the "Requested by" rule field renders a searchable combobox (`RequesterWidget`) populated from that endpoint, mirroring the existing "Watched by user" picker. Free-typing is still allowed.

### Sync logging for Overseerr requester resolution
So it's visible whether a sync actually collected requester data:
- A per-scan line stating whether Overseerr is connected.
- A per-library summary: how many items resolved a requester, across how many users, and how many matched Sonarr/Radarr.
- The previously silent Overseerr lookup failure now logs a warning once per scan (instead of being swallowed per item).

## Verification

- `npm run build` (server + client): passes
- Server tests: 45/45 passing

After merging, push a new version tag (next would be `v1.4.14`) to trigger the Docker build.

https://claude.ai/code/session_01KvF7ygLVjHgpnAnwc9qxJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvF7ygLVjHgpnAnwc9qxJY)_