### PR TITLE
Improve mobile Rules layout and smooth out animation FPS

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -41,6 +41,8 @@ function AnimatedRoutes() {
         animate={{ opacity: 1, y: 0 }}
         exit={reduce ? { opacity: 1 } : { opacity: 0, y: -4 }}
         transition={transition}
+        onAnimationStart={() => document.documentElement.classList.add('page-animating')}
+        onAnimationComplete={() => document.documentElement.classList.remove('page-animating')}
       >
         <Routes location={location}>
           <Route path="/" element={<Dashboard />} />

--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -28,6 +28,24 @@ export default function Layout({ children }: LayoutProps) {
   const wasOpen = useRef(false);
   const isHorizontalSwipe = useRef<boolean | null>(null);
   const backdropHideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const navAnimTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Suspend descendant backdrop-filters while the sidebar is moving (see the
+  // `.nav-animating` rule in index.css). Pass a duration to auto-clear after the
+  // snap settles, or null to hold it on for the duration of a live drag.
+  const suspendBlurDuringNav = useCallback((clearAfterMs: number | null) => {
+    document.documentElement.classList.add('nav-animating');
+    if (navAnimTimer.current) {
+      clearTimeout(navAnimTimer.current);
+      navAnimTimer.current = null;
+    }
+    if (clearAfterMs !== null) {
+      navAnimTimer.current = setTimeout(() => {
+        document.documentElement.classList.remove('nav-animating');
+        navAnimTimer.current = null;
+      }, clearAfterMs);
+    }
+  }, []);
 
   // Close mobile menu on route change
   useEffect(() => {
@@ -51,6 +69,10 @@ export default function Layout({ children }: LayoutProps) {
     const backdrop = backdropRef.current;
     if (!sidebar) return;
 
+    // Hold blur suspended for the whole live drag; touch-end's snapTo schedules
+    // the restore once the gesture settles.
+    suspendBlurDuringNav(null);
+
     // Clamp between -SIDEBAR_WIDTH (fully hidden) and 0 (fully visible)
     const clamped = Math.max(-SIDEBAR_WIDTH, Math.min(0, offsetX));
     sidebar.style.transform = `translateX(${clamped}px)`;
@@ -62,12 +84,15 @@ export default function Layout({ children }: LayoutProps) {
       backdrop.style.display = progress > 0 ? 'block' : 'none';
       backdrop.style.transition = 'none';
     }
-  }, []);
+  }, [suspendBlurDuringNav]);
 
   // Snap to open or closed with animation
   const snapTo = useCallback((open: boolean) => {
     const sidebar = sidebarRef.current;
     const backdrop = backdropRef.current;
+
+    // Snap runs a 300ms transition; suspend blur for that window then restore.
+    suspendBlurDuringNav(300);
 
     if (sidebar) {
       sidebar.style.transition = 'transform 300ms cubic-bezier(0.4, 0, 0.2, 1)';
@@ -92,7 +117,7 @@ export default function Layout({ children }: LayoutProps) {
     }
 
     setMobileMenuOpen(open);
-  }, []);
+  }, [suspendBlurDuringNav]);
 
   // Touch handlers
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
@@ -194,6 +219,8 @@ export default function Layout({ children }: LayoutProps) {
 
     // Only reset styles if not mid-drag
     if (!isDragging.current) {
+      // Button/route-driven open/close also runs the 300ms transition.
+      suspendBlurDuringNav(300);
       sidebar.style.transition = 'transform 300ms cubic-bezier(0.4, 0, 0.2, 1)';
       sidebar.style.transform = mobileMenuOpen ? 'translateX(0)' : `translateX(-${SIDEBAR_WIDTH}px)`;
 
@@ -215,7 +242,15 @@ export default function Layout({ children }: LayoutProps) {
         }
       }
     }
-  }, [mobileMenuOpen]);
+  }, [mobileMenuOpen, suspendBlurDuringNav]);
+
+  // Clean up the blur-suspension timer/class on unmount
+  useEffect(() => {
+    return () => {
+      if (navAnimTimer.current) clearTimeout(navAnimTimer.current);
+      document.documentElement.classList.remove('nav-animating');
+    };
+  }, []);
 
   return (
     <div

--- a/client/src/components/Rules/Rules.tsx
+++ b/client/src/components/Rules/Rules.tsx
@@ -227,11 +227,11 @@ function RuleCard({
   return (
     <Card className={`transition-colors ${!rule.enabled ? 'opacity-60' : ''}`}>
       <div className="p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3 sm:items-center sm:gap-4 min-w-0">
             <button
               onClick={() => onToggle(!rule.enabled)}
-              className={`px-3 py-1.5 rounded-lg transition-colors text-xs font-medium ${
+              className={`shrink-0 px-3 py-1.5 rounded-lg transition-colors text-xs font-medium ${
                 rule.enabled
                   ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30'
                   : 'bg-surface-700 text-surface-400 hover:bg-surface-600'
@@ -239,9 +239,9 @@ function RuleCard({
             >
               {rule.enabled ? 'Active' : 'Inactive'}
             </button>
-            <div>
-              <div className="flex items-center gap-2">
-                <h3 className="font-medium text-surface-50">{rule.name}</h3>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="font-medium text-surface-50 break-words">{rule.name}</h3>
                 <span
                   className="text-xs font-mono px-1.5 py-0.5 rounded bg-surface-700 text-surface-400"
                   title="Rule priority (higher wins)"
@@ -276,7 +276,7 @@ function RuleCard({
             </div>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 self-end sm:gap-2 sm:self-auto shrink-0">
             <Button
               variant="ghost"
               size="sm"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -129,6 +129,38 @@
   z-index: 9999;
 }
 
+/*
+ * Perf: while a page route transition or the mobile sidebar is mid-animation,
+ * an ancestor's transform/opacity changes every frame. `backdrop-filter` has
+ * to re-sample its backdrop on each of those frames, which drops frames on
+ * mobile. The blurred surfaces here (cards, header, glass) sit on a near-solid
+ * app background, so suspending the blur for the ~220–300ms a transition runs
+ * is imperceptible at rest while keeping the motion smooth. The classes are
+ * added/removed by App.tsx (page transitions) and Layout.tsx (sidebar), and
+ * the filter is restored the instant the animation settles.
+ */
+.page-animating *,
+.nav-animating * {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+/*
+ * `backdrop-filter` should never animate via `transition-all`: interpolating a
+ * blur is expensive and would "focus-pull" the frosting when it's restored
+ * after a transition. Re-declare the transition set as Tailwind's default list
+ * minus backdrop-filter so every visible property still animates normally while
+ * the blur snaps instantly (invisible over the flat background, no pull over
+ * poster art). Unlayered, so it overrides the layered `transition-all` utility.
+ */
+.card,
+.glass,
+.glass-subtle,
+[class*='backdrop-blur'] {
+  transition-property: color, background-color, border-color, text-decoration-color,
+    fill, stroke, opacity, box-shadow, transform, filter;
+}
+
 @layer components {
   /* Glass card effect */
   .glass {


### PR DESCRIPTION
## Summary

Two mobile-focused UI improvements.

### 1. Rules cards layout on mobile
The rule card header was a single non-wrapping `flex justify-between` row at every screen size, so on a phone the title block was squeezed into a narrow column (long names broke one word per line) while four action icons hogged the right side.

- Header is now mobile-first: the title/status block stacks above the action buttons on small screens, badges wrap, and the original side-by-side layout returns at the `sm:` breakpoint.
- Desktop appearance is unchanged.

### 2. Smoother page/sidebar animations
Animating an ancestor's `transform`/`opacity` forces every descendant `backdrop-filter` to re-rasterize each frame, which dropped frames on mobile during route changes and sidebar open/close (the app uses frosted cards/header).

- A class is toggled on the document element while the page transition (`App.tsx`) and sidebar (`Layout.tsx`) are mid-animation, suspending `backdrop-filter` and restoring it the instant motion settles.
- The blurred surfaces sit on a near-solid background, so the **resting appearance is unchanged** — the blur is only paused for the ~220–300ms a transition runs, when it's imperceptible anyway.
- A companion rule keeps `backdrop-filter` out of `transition-all` so the frosting snaps back instantly instead of focus-pulling; all visible properties still transition normally.

## Verification
- `client` builds clean (`vite build`), TypeScript passes (`tsc --noEmit`), CSS compiles.
- Not yet exercised on physical hardware — the FPS improvement and on-device feel should be confirmed on a real mobile device.

https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj