### PR TITLE
Drop invisible backdrop-blur from live-preview chip and sheet for smoother swipe-up

### DIFF
--- a/client/src/components/Rules/LivePreview.tsx
+++ b/client/src/components/Rules/LivePreview.tsx
@@ -104,7 +104,7 @@ export function LivePreview({ root, mediaType = 'all', enabled = true, onSummary
   }, [preview, error, isPending, debouncedRoot, onSummaryChange]);
 
   return (
-    <Card className="p-5 bg-surface-800/50 h-full flex flex-col">
+    <Card className="p-5 bg-surface-800/50 h-full flex flex-col backdrop-blur-none">
       <h4 className="text-sm font-medium text-surface-300 mb-4 flex items-center gap-2">
         <Eye className="w-4 h-4" />
         Live Preview

--- a/client/src/components/Rules/MobilePreviewSheet.tsx
+++ b/client/src/components/Rules/MobilePreviewSheet.tsx
@@ -74,7 +74,7 @@ export function MobilePreviewSheet({
                 ? { duration: 0.1 }
                 : { type: 'spring', stiffness: 380, damping: 28 }
             }
-            className="fixed inset-x-0 mx-auto z-[60] flex items-center gap-2 px-4 py-2.5 bg-surface-900/95 backdrop-blur-xl border border-accent-500/40 rounded-full shadow-lg shadow-black/40 text-sm text-surface-100 active:scale-[0.98] transition-transform"
+            className="fixed inset-x-0 mx-auto z-[60] flex items-center gap-2 px-4 py-2.5 bg-surface-900/95 border border-accent-500/40 rounded-full shadow-lg shadow-black/40 text-sm text-surface-100 active:scale-[0.98] transition-transform"
             style={{
               width: 'fit-content',
               maxWidth: 'calc(100vw - 2rem)',


### PR DESCRIPTION
## Summary

Removes the most expensive blur in the app from the mobile live-preview chip and sheet content, smoothing out the swipe-up gesture on the Rules builder. Resting appearance is unchanged.

### The chip (`MobilePreviewSheet.tsx`)
The floating live-preview chip carried `backdrop-blur-xl` while continuously animating its **own** transform — a spring entrance/exit (`y` via `AnimatePresence`) plus `active:scale-[0.98]` on every press. Because the blurred element is the one being transformed, the heaviest blur radius in the app re-rasterized on every frame of every chip gesture, most visibly when swiping up to open the sheet.

At `bg-surface-900/95` (95% opaque) that blur was imperceptible anyway, so it's dropped. The chip looks identical and stops re-blurring per frame.

### The sheet content (`LivePreview.tsx`)
The preview panel's wrapping `Card` carried `backdrop-blur-sm` (from the shared `Card` variant). While the sheet is dragged, that blurred card moved with it and re-rasterized each frame. It sits on the opaque sheet, so the blur was invisible. Dropped via `backdrop-blur-none` on that one instance — `tailwind-merge` overrides the shared variant without touching any other `Card`.

The sample match list was already capped at 10 rows, so no virtualization concern there.

## Verification
- `client` builds clean (`vite build`), TypeScript passes (`tsc --noEmit`).
- 2 files, +2/−2 (just the two blur classes).
- Not yet exercised on physical hardware — the swipe-up smoothness should be confirmed on a real mobile device.

Follow-up to #36; intentionally separate so it can be released on its own.

https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj

---
_Generated by [Claude Code](https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj)_