### PR TITLE
Portal mobile preview chip/sheet to body to stop full-screen flash on slide-up

### DIFF
--- a/client/src/components/Rules/MobilePreviewSheet.tsx
+++ b/client/src/components/Rules/MobilePreviewSheet.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import {
   AnimatePresence,
   motion,
@@ -57,7 +58,13 @@ export function MobilePreviewSheet({
     }
   };
 
-  return (
+  // Portal to document.body so the fixed chip/sheet are positioned relative to
+  // the viewport, not the SmartRuleBuilder modal container. That container has
+  // `backdrop-blur`, which makes it the containing block for our fixed
+  // descendants; combined with framer's transform animation, Chrome
+  // intermittently re-resolves the containing block mid-animation, making the
+  // sheet flash to full screen as it slides up. Escaping to the body fixes it.
+  return createPortal(
     <div className="lg:hidden">
       {/* Floating chip — visible whenever the sheet is closed */}
       <AnimatePresence>
@@ -167,7 +174,8 @@ export function MobilePreviewSheet({
           />
         </div>
       </motion.div>
-    </div>
+    </div>,
+    document.body
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes the mobile live-preview sheet **flashing/jumping to full screen** while it slides up from the chip.

## Root cause

The chip and bottom sheet render **inside** the `SmartRuleBuilder` modal container, which has `backdrop-blur-sm`:

```jsx
<div className="fixed inset-0 z-50 ... backdrop-blur-sm ...">
  ...
  <MobilePreviewSheet />
</div>
```

`backdrop-filter` makes that container the **containing block** for its `position: fixed` descendants. The sheet animates its transform via framer-motion (`animate={{ y: '100%' → '0%' }}`), and framer toggles `will-change: transform` for the duration of the animation. When a `fixed` element animates a transform while its containing block is established by an ancestor's `backdrop-filter`, Chrome (notably on Android) intermittently re-resolves the containing block mid-animation — flip-flopping between the blurred ancestor and the viewport. Each flip re-lays-out the sheet for a frame, which reads as the full-screen flash.

## Fix

Render the chip/sheet through `createPortal(..., document.body)` — the same pattern `SmartRuleBuilder` already uses for itself. Their containing block becomes the real viewport, so the `fixed` positioning is stable and the flash is gone.

Visual stacking is unchanged: the chip (`z-[60]`), backdrop (`z-[60]`), and sheet (`z-[61]`) still sit above the `z-50` builder, and the portal is appended after the builder in the DOM.

## Verification
- `client` builds clean (`vite build`), TypeScript passes (`tsc --noEmit`).
- 1 file, +10/−2.
- Not yet exercised on physical hardware — the slide-up should be confirmed flash-free on a real mobile device.

Independent of #36 and #37 (branched off `main`) so it can be released on its own. Note: #37 also edits `MobilePreviewSheet.tsx` (removing the chip's `backdrop-blur`), but on a non-overlapping line, so they merge cleanly in either order.

https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj

---
_Generated by [Claude Code](https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj)_