### PR TITLE
Add a user setting to toggle haptic feedback

### DIFF
--- a/client/src/components/Rules/MobilePreviewSheet.tsx
+++ b/client/src/components/Rules/MobilePreviewSheet.tsx
@@ -8,6 +8,7 @@ import {
 } from 'framer-motion';
 import { Eye, ChevronUp, X, AlertCircle } from 'lucide-react';
 import { LivePreview, type LivePreviewSummary } from './LivePreview';
+import { haptic } from '@/lib/haptics';
 import type { ConditionNode } from '@/types';
 
 interface MobilePreviewSheetProps {
@@ -38,13 +39,8 @@ export function MobilePreviewSheet({
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const hasOpened = useRef(false);
 
-  // Light haptic tick on open/close/dismiss where supported (Android/Chrome).
-  // No-op on iOS Safari, which ignores the Vibration API.
-  const haptic = (ms = 8) => {
-    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
-      navigator.vibrate(ms);
-    }
-  };
+  // A light haptic tick on open/close/dismiss; respects the user's haptics
+  // preference and no-ops where the Vibration API is unsupported.
   const openSheet = () => {
     haptic();
     setOpen(true);

--- a/client/src/components/Settings/Settings.tsx
+++ b/client/src/components/Settings/Settings.tsx
@@ -27,6 +27,7 @@ import {
   Eye,
   KeyRound,
   EyeOff,
+  Smartphone,
 } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
@@ -45,6 +46,7 @@ import {
 import { apiKeyApi, type ApiKeyInfo } from '@/services/api';
 import type { Settings as SettingsType, ServiceConnection, DisplaySettings } from '@/types';
 import { useDisplayPreferences } from '@/contexts/DisplayPreferencesContext';
+import { useHapticsEnabled } from '@/lib/haptics';
 
 type ServiceField = 'url' | 'apiKey' | 'token';
 type ServiceKeyType = 'plex' | 'tautulli' | 'tracearr' | 'sonarr' | 'radarr' | 'overseerr' | 'unraid';
@@ -1392,6 +1394,9 @@ export default function Settings() {
       {/* Display Preferences */}
       <DisplayPreferencesCard />
 
+      {/* Haptic Feedback */}
+      <HapticsPreferenceCard />
+
       {/* Backup & Restore */}
       <Card>
         <CardHeader>
@@ -1687,6 +1692,37 @@ function ServiceConnectionForm({
         </Button>
       </div>
     </div>
+  );
+}
+
+function HapticsPreferenceCard() {
+  const [hapticsEnabled, setHapticsEnabled] = useHapticsEnabled();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-amber-500/10">
+            <Smartphone className="w-5 h-5 text-amber-400" />
+          </div>
+          <div>
+            <CardTitle>Haptic Feedback</CardTitle>
+            <CardDescription>Vibration on touch interactions — supported mobile devices only</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-surface-200">Enable haptics</p>
+            <p className="text-xs text-surface-500 mt-0.5">
+              A subtle tap when opening, closing, and dismissing sheets. Saved per device.
+            </p>
+          </div>
+          <ToggleSwitch checked={hapticsEnabled} onChange={setHapticsEnabled} />
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/client/src/lib/haptics.ts
+++ b/client/src/lib/haptics.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Per-device haptic-feedback preference. Stored in localStorage (like the theme
+ * and library view-mode) because vibration is inherently device-specific — your
+ * phone vibrates, your desktop doesn't. Defaults to enabled.
+ */
+const STORAGE_KEY = 'prunerr:haptics';
+
+export function isHapticsEnabled(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== 'off';
+  } catch {
+    // localStorage can throw in private mode / sandboxed contexts.
+    return true;
+  }
+}
+
+function writeHapticsEnabled(enabled: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, enabled ? 'on' : 'off');
+  } catch {
+    /* ignore — preference just won't persist */
+  }
+}
+
+/**
+ * Fire a short haptic tick, if the device supports the Vibration API and the
+ * user hasn't disabled haptics. No-op everywhere else (e.g. iOS Safari).
+ */
+export function haptic(ms = 8): void {
+  if (!isHapticsEnabled()) return;
+  if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+    navigator.vibrate(ms);
+  }
+}
+
+/** Reactive accessor for the haptics preference, for use in settings UI. */
+export function useHapticsEnabled(): [boolean, (enabled: boolean) => void] {
+  const [enabled, setEnabled] = useState(isHapticsEnabled);
+  const update = useCallback((next: boolean) => {
+    writeHapticsEnabled(next);
+    setEnabled(next);
+  }, []);
+  return [enabled, update];
+}


### PR DESCRIPTION
## Summary

Makes the preview-sheet haptics (shipped in #39) **user-configurable**, as requested.

- Adds a **"Haptic Feedback"** toggle to the Settings page (its own card, using the existing `ToggleSwitch`).
- The preference is stored in **localStorage** — per-device, matching the theme and library view-mode patterns, since vibration is inherently device-specific (your phone vibrates; your desktop doesn't). Defaults to **on**.
- The preview sheet's `haptic()` now consults the preference, so turning it off silences the open / close / swipe-dismiss ticks. Still a no-op where the Vibration API is unsupported (e.g. iOS Safari).
- Extracted the haptic helper into `client/src/lib/haptics.ts` (`haptic`, `isHapticsEnabled`, `useHapticsEnabled`) so it's shared rather than inlined in the component.

### Why localStorage instead of server settings
The server persists `settings.display.*` as string key-value pairs, so a server-backed boolean would round-trip as the string `"false"` (which is truthy) — fragile. A per-device localStorage flag avoids that and is the correct semantics for haptics anyway.

## Verification
- `client` builds clean (`vite build`), TypeScript passes (`tsc --noEmit`), tests 35/35.
- 3 files, +85/−7.

Branches off current `main` (which already includes the merged #39). Independent of the open #40.

https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj

---
_Generated by [Claude Code](https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj)_