### PR TITLE
Fix yellow-on-yellow grace-period chip (warning badge) in light mode

### DIFF
--- a/client/src/components/common/Badge.tsx
+++ b/client/src/components/common/Badge.tsx
@@ -32,7 +32,7 @@ export function Badge({
     default: 'bg-surface-700/50 text-surface-300 border-surface-600/30',
     accent: 'bg-accent-500/15 text-accent-text border-accent-500/20',
     success: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
-    warning: 'bg-amber-500/15 text-amber-200 border-amber-500/30',
+    warning: 'bg-amber-500/15 text-accent-text border-amber-500/30',
     danger: 'bg-ruby-500/15 text-ruby-400 border-ruby-500/20',
     movie: 'bg-violet-500/15 text-violet-400 border-violet-500/20',
     tv: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',


### PR DESCRIPTION
## Summary

Fixes the unreadable **yellow-text-on-yellow** grace-period chip in the dashboard's Recent Activity.

The `{N}d grace` chip uses the `Badge` `warning` variant (`variant: 'warning'` in `lib/activityFormatter.ts`). That variant was:

```
warning: 'bg-amber-500/15 text-amber-200 border-amber-500/30'
```

Every other Badge variant uses a `-400` text shade, but `warning` uniquely used `text-amber-200` — a very pale yellow. On a dark surface it's fine, but in **light mode** the `bg-amber-500/15` becomes a pale yellow wash and pale-yellow text on it is illegible.

Switched the text to the existing **theme-aware** `text-accent-text` token (the same one the `accent` variant uses): dark amber in light mode, light amber in dark mode — legible in both. Only the text color changed; the amber background/border are unchanged.

This fixes the chip everywhere the `warning` variant is used, not just the dashboard.

## Verification
- `client` builds clean (`vite build`), TypeScript passes (`tsc --noEmit`).
- 1 line changed.

Branches off current `main`; independent of the open #40 and #41.

https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj

---
_Generated by [Claude Code](https://claude.ai/code/session_011WpWTydBcGtKP9ufeit3xj)_