### PR TITLE
Fix Reclaimable card overcounting vs. queue; backfill stuck queued items

### DIFF
--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -385,6 +385,29 @@ const migrations: Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_unraid_capacity_snapshots_captured_at ON unraid_capacity_snapshots(captured_at);
     `,
   },
+  {
+    version: 18,
+    name: 'backfill_stuck_pending_deletion',
+    up: `
+      -- Repair items stuck in 'pending_deletion' without the marked_at /
+      -- delete_after timestamps the queue requires. These were counted by the
+      -- dashboard "Reclaimable" card but hidden from the Queue page (which
+      -- filters on delete_after), so the two disagreed. Backfill the timestamps
+      -- from the best available time + the default 7-day grace period so the
+      -- items become real, visible queue entries instead of silently dropping
+      -- media the user intended to delete.
+      UPDATE media_items
+      SET marked_at = COALESCE(marked_at, updated_at, created_at, datetime('now'))
+      WHERE status = 'pending_deletion' AND marked_at IS NULL;
+
+      UPDATE media_items
+      SET delete_after = datetime(
+        COALESCE(marked_at, updated_at, created_at, datetime('now')),
+        '+7 days'
+      )
+      WHERE status = 'pending_deletion' AND delete_after IS NULL;
+    `,
+  },
 ];
 
 // Schema version tracking table

--- a/server/src/routes/stats.ts
+++ b/server/src/routes/stats.ts
@@ -19,8 +19,14 @@ router.get('/', (_req: Request, res: Response) => {
     // Get deletion stats
     const deletionStats = rulesRepo.deletionHistory.getStats();
 
-    // Get pending deletion items
-    const pendingDeletion = mediaItemsRepo.getPendingDeletion();
+    // Get pending deletion items. Mirror the Queue route's filter
+    // (delete_after && marked_at) so the "Reclaimable" card's count and space
+    // match what the Queue page actually shows. Items left in pending_deletion
+    // without a delete_after are stuck/legacy rows the queue can't render, and
+    // counting them here is what made the card overcount vs. the queue.
+    const pendingDeletion = mediaItemsRepo
+      .getPendingDeletion()
+      .filter((item) => item.delete_after && item.marked_at);
 
     // Get latest scan
     const latestScan = rulesRepo.scanHistory.getLatest();


### PR DESCRIPTION
## Problem
The dashboard **Reclaimable** card reported more queued items than the Queue page (in production: card *"9 items queued"* vs. **2** in the queue).

## Cause
Both come from `mediaItemsRepo.getPendingDeletion()` (status = `pending_deletion`), but:
- **Card** (`/api/stats`) counted **every** such row.
- **Queue** (`/api/queue`) additionally filters to items with **`delete_after` AND `marked_at`** set.

Items stuck in `pending_deletion` without those timestamps were counted by the card but hidden from the queue — so the two diverged.

## Fix
1. **`stats.ts`** — apply the same `delete_after && marked_at` filter for both `itemsMarkedForDeletion` and `reclaimableSpace`, so card and queue share one definition and can't drift.
2. **Migration v18** — backfill the stuck rows: `marked_at` from `updated_at`/`created_at`, and `delete_after = marked_at + 7 days` (the default grace period), turning them into real, visible queue entries rather than silently un-queueing media the user intended to delete.

## Verification note
Could not reproduce on the local DB (all 271 pending items already have timestamps), so this is verified by logic, not local repro. To confirm on production:
```sql
SELECT COUNT(*) AS total_pending,
       SUM(CASE WHEN delete_after IS NULL THEN 1 ELSE 0 END) AS missing_delete_after,
       SUM(CASE WHEN marked_at   IS NULL THEN 1 ELSE 0 END) AS missing_marked_at
FROM media_items WHERE status = 'pending_deletion';
```
Regardless of cause, the card and queue now use identical filters, so they can no longer disagree.

## Notes
- Affects the Docker image (server) and runs a data migration on startup. Needs a `v1.x.x` tag to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)