### PR TITLE
Disk-pressure reactive mode + outbound webhooks / Home Assistant

### DIFF
--- a/client/src/components/Layout/DiskPressureWidget.tsx
+++ b/client/src/components/Layout/DiskPressureWidget.tsx
@@ -1,0 +1,101 @@
+import { Gauge } from 'lucide-react';
+import { cn, formatBytes } from '@/lib/utils';
+import type { DashboardStats } from '@/types';
+
+interface DiskPressureWidgetProps {
+  stats: DashboardStats | undefined;
+}
+
+/**
+ * Compact free-space gauge for the disk-pressure feature. Mirrors StorageWidget's
+ * visual language but is driven by the real free-space fields from /api/stats
+ * (statfs) rather than Unraid. Renders only when those fields are present.
+ */
+export function DiskPressureWidget({ stats }: DiskPressureWidgetProps) {
+  const total = stats?.diskTotalBytes ?? null;
+  const used = stats?.diskUsedBytes ?? null;
+  const free = stats?.diskFreeBytes ?? null;
+  const target = stats?.diskTargetBytes ?? null;
+
+  if (total === null || used === null || free === null || total <= 0) {
+    return null;
+  }
+
+  const severity = stats?.diskPressureSeverity ?? 'ok';
+  const pct = (used / total) * 100;
+
+  const ringClass =
+    severity === 'critical' ? 'text-ruby-500' : severity === 'soft' ? 'text-amber-500' : 'text-accent-500';
+  const textClass =
+    severity === 'critical' ? 'text-ruby-400' : severity === 'soft' ? 'text-amber-400' : 'text-accent-text';
+
+  const r = 22;
+  const circ = 2 * Math.PI * r;
+  const offset = circ * (1 - pct / 100);
+  // Target marker: the used% at which free space would hit the target line.
+  const targetUsedPct = target !== null && total > 0 ? Math.max(0, Math.min(100, ((total - target) / total) * 100)) : null;
+
+  return (
+    <div
+      className={cn(
+        'w-full p-3.5 rounded-2xl text-left',
+        'bg-gradient-to-b from-surface-800/55 to-surface-800/30',
+        'border border-surface-700/45',
+        'shadow-[0_1px_0_rgb(255_255_255/0.02)_inset,0_8px_24px_-16px_rgb(0_0_0/0.4)]',
+      )}
+    >
+      <div className="relative flex items-center gap-3.5">
+        <div className="relative w-[60px] h-[60px] flex-shrink-0">
+          <svg className="relative w-[60px] h-[60px] -rotate-90 overflow-visible" viewBox="0 0 56 56">
+            <circle cx="28" cy="28" r={r} fill="none" strokeWidth="5" className="text-surface-700/70" stroke="currentColor" />
+            {targetUsedPct !== null && (
+              <circle
+                cx="28" cy="28" r={r}
+                fill="none"
+                strokeWidth="5"
+                strokeLinecap="round"
+                className="text-surface-300/80"
+                stroke="currentColor"
+                strokeDasharray={`1.5 ${circ}`}
+                strokeDashoffset={-circ * (targetUsedPct / 100)}
+              />
+            )}
+            <circle
+              cx="28" cy="28" r={r}
+              fill="none"
+              strokeWidth="5"
+              strokeLinecap="round"
+              className={ringClass}
+              stroke="currentColor"
+              strokeDasharray={circ}
+              strokeDashoffset={offset}
+              style={{
+                transition: 'stroke-dashoffset 900ms cubic-bezier(0.4, 0, 0.2, 1)',
+                filter: 'drop-shadow(0 0 3px currentColor)',
+              }}
+            />
+          </svg>
+          <div className={cn('absolute inset-0 flex items-center justify-center font-display font-bold text-sm tabular-nums', textClass)}>
+            {Math.round(pct)}
+            <span className="text-[9px] ml-px opacity-75">%</span>
+          </div>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="text-[9.5px] font-bold uppercase tracking-[0.16em] text-surface-500 flex items-center gap-1">
+            <Gauge className="w-3 h-3" /> Free Space
+          </p>
+          <p className="font-display font-bold text-[22px] leading-none text-surface-50 tabular-nums -tracking-[0.02em] mt-0.5">
+            {formatBytes(free)}
+          </p>
+          <p className="text-[11px] text-surface-500 mt-0.5 tabular-nums">free of {formatBytes(total)}</p>
+          {target !== null && (
+            <p className={cn('text-[10.5px] font-semibold mt-1.5 tabular-nums', textClass)}>
+              {severity === 'ok' ? 'Above target' : severity === 'soft' ? 'Below target' : 'Critically low'} · keep {formatBytes(target)}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/Layout/Sidebar.tsx
+++ b/client/src/components/Layout/Sidebar.tsx
@@ -20,10 +20,11 @@ import {
   Moon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useUnraidStats, useDeletionQueue, useVersion } from '@/hooks/useApi';
+import { useUnraidStats, useDeletionQueue, useVersion, useStats } from '@/hooks/useApi';
 import { useTheme } from '@/contexts/ThemeContext';
 import { DiskStatsModal } from './DiskStatsModal';
 import { StorageWidget } from './StorageWidget';
+import { DiskPressureWidget } from './DiskPressureWidget';
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: LayoutDashboard },
@@ -45,6 +46,7 @@ const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(function Sidebar({ onCl
   const location = useLocation();
   const [isDiskStatsOpen, setIsDiskStatsOpen] = useState(false);
   const { data: unraidStats } = useUnraidStats();
+  const { data: dashboardStats } = useStats();
   const { data: queueItems } = useDeletionQueue();
   const { data: version } = useVersion();
   const { resolvedTheme, toggleTheme } = useTheme();
@@ -129,11 +131,15 @@ const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(function Sidebar({ onCl
       </nav>
 
       {/* Storage Widget */}
-      <div className="p-4 border-t border-surface-800/50">
+      <div className="p-4 border-t border-surface-800/50 space-y-3">
         <StorageWidget
           stats={unraidStats}
           onClick={() => setIsDiskStatsOpen(true)}
         />
+        {/* Free-space gauge from statfs — shown when Unraid isn't the source */}
+        {!unraidStats?.configured && dashboardStats?.diskPressureEnabled && (
+          <DiskPressureWidget stats={dashboardStats} />
+        )}
       </div>
 
       {/* Disk Stats Modal */}

--- a/client/src/components/Settings/Settings.tsx
+++ b/client/src/components/Settings/Settings.tsx
@@ -28,6 +28,8 @@ import {
   KeyRound,
   EyeOff,
   Smartphone,
+  Webhook,
+  Gauge,
 } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
@@ -41,10 +43,46 @@ import {
   useSettings,
   useSaveSettings,
   useTestConnection,
+  useTestWebhook,
   useImportSettings,
 } from '@/hooks/useApi';
 import { apiKeyApi, type ApiKeyInfo } from '@/services/api';
-import type { Settings as SettingsType, ServiceConnection, DisplaySettings } from '@/types';
+import type {
+  Settings as SettingsType,
+  ServiceConnection,
+  DisplaySettings,
+  WebhookTarget,
+  NotificationEventName,
+} from '@/types';
+
+// Events a webhook can subscribe to, with friendly labels.
+const WEBHOOK_EVENTS: Array<{ value: NotificationEventName; label: string }> = [
+  { value: 'SCAN_COMPLETE', label: 'Scan complete' },
+  { value: 'SCAN_ERROR', label: 'Scan error' },
+  { value: 'ITEMS_MARKED', label: 'Items queued' },
+  { value: 'DELETION_IMMINENT', label: 'Deletion imminent' },
+  { value: 'DELETION_COMPLETE', label: 'Deletion complete' },
+  { value: 'DELETION_ERROR', label: 'Deletion error' },
+  { value: 'DISK_PRESSURE_TRIGGERED', label: 'Disk pressure' },
+];
+
+// Suppress password-manager autofill on webhook fields. The optional "secret"
+// field makes managers treat the panel as a login form and autofill name/url;
+// autoComplete + the per-manager ignore hints stop all the major ones.
+const noAutofill = {
+  autoComplete: 'off',
+  'data-1p-ignore': true,
+  'data-lpignore': 'true',
+  'data-bwignore': true,
+  'data-form-type': 'other',
+} as const;
+
+const DELETION_ACTION_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'unmonitor_and_delete', label: 'Unmonitor & delete files' },
+  { value: 'delete_files_only', label: 'Delete files only' },
+  { value: 'full_removal', label: 'Full removal' },
+  { value: 'unmonitor_only', label: 'Unmonitor only (keep files)' },
+];
 import { useDisplayPreferences } from '@/contexts/DisplayPreferencesContext';
 import { useHapticsEnabled } from '@/lib/haptics';
 
@@ -491,6 +529,80 @@ export default function Settings() {
 
     // Clear result after 5 seconds
     setTimeout(() => setDiscordTestResult({ status: 'idle' }), 5000);
+  };
+
+  // --- Webhooks ---
+  const webhooks: WebhookTarget[] = (currentSettings.webhooks as WebhookTarget[]) ?? [];
+  const testWebhookMutation = useTestWebhook();
+  const [webhookTestResults, setWebhookTestResults] = useState<
+    Record<string, { status: 'idle' | 'loading' | 'success' | 'error'; message?: string }>
+  >({});
+
+  const updateWebhooks = (next: WebhookTarget[]) => {
+    setLocalSettings((prev) => ({ ...prev, webhooks: next }));
+  };
+
+  const handleAddWebhook = () => {
+    const id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `wh_${Date.now()}`;
+    updateWebhooks([...webhooks, { id, name: '', url: '', events: [], enabled: true }]);
+  };
+
+  const handleRemoveWebhook = (id: string) => {
+    updateWebhooks(webhooks.filter((w) => w.id !== id));
+  };
+
+  const handleWebhookChange = (id: string, updates: Partial<WebhookTarget>) => {
+    updateWebhooks(webhooks.map((w) => (w.id === id ? { ...w, ...updates } : w)));
+  };
+
+  const handleToggleWebhookEvent = (id: string, event: NotificationEventName) => {
+    updateWebhooks(
+      webhooks.map((w) => {
+        if (w.id !== id) return w;
+        const has = w.events.includes(event);
+        return { ...w, events: has ? w.events.filter((e) => e !== event) : [...w.events, event] };
+      })
+    );
+  };
+
+  const handleTestWebhook = async (target: WebhookTarget) => {
+    if (!target.url) {
+      setWebhookTestResults((prev) => ({ ...prev, [target.id]: { status: 'error', message: 'Enter a URL first' } }));
+      return;
+    }
+    setWebhookTestResults((prev) => ({ ...prev, [target.id]: { status: 'loading' } }));
+    try {
+      const res = await testWebhookMutation.mutateAsync({ url: target.url, secret: target.secret });
+      setWebhookTestResults((prev) => ({
+        ...prev,
+        [target.id]: { status: 'success', message: `Delivered (HTTP ${res.status ?? 200})` },
+      }));
+    } catch (error) {
+      setWebhookTestResults((prev) => ({
+        ...prev,
+        [target.id]: { status: 'error', message: error instanceof Error ? error.message : 'Delivery failed' },
+      }));
+    }
+    setTimeout(() => setWebhookTestResults((prev) => ({ ...prev, [target.id]: { status: 'idle' } })), 5000);
+  };
+
+  // --- Disk Pressure ---
+  const dp = currentSettings.diskPressure ?? {};
+  const handleDiskPressureChange = (
+    field: keyof NonNullable<SettingsType['diskPressure']>,
+    value: string | number | boolean | string[]
+  ) => {
+    setLocalSettings((prev) => ({
+      ...prev,
+      diskPressure: {
+        ...currentSettings.diskPressure,
+        ...prev.diskPressure,
+        [field]: value,
+      },
+    }));
   };
 
   const handleScheduleChange = (field: keyof NonNullable<SettingsType['schedule']>, value: string | number | boolean) => {
@@ -942,6 +1054,339 @@ export default function Settings() {
                     />
                   </div>
                 </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Outbound Webhooks */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-cyan-500/10">
+              <Webhook className="w-5 h-5 text-cyan-400" />
+            </div>
+            <div>
+              <CardTitle>Outbound Webhooks</CardTitle>
+              <CardDescription>
+                POST events to any URL — wire Prunerr into Home Assistant, n8n, or your own automations
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {webhooks.length === 0 && (
+            <p className="text-sm text-surface-400">
+              No webhooks configured. Add one to start sending events.
+            </p>
+          )}
+
+          {webhooks.map((wh) => {
+            const result = webhookTestResults[wh.id] ?? { status: 'idle' };
+            return (
+              <div
+                key={wh.id}
+                className="p-4 rounded-xl bg-surface-800/40 border border-surface-700/30 space-y-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 space-y-3">
+                    <Input
+                      label="Name (optional)"
+                      value={wh.name || ''}
+                      onChange={(e) => handleWebhookChange(wh.id, { name: e.target.value })}
+                      placeholder="Home Assistant"
+                      {...noAutofill}
+                    />
+                    <Input
+                      label="URL"
+                      type="url"
+                      value={wh.url}
+                      onChange={(e) => handleWebhookChange(wh.id, { url: e.target.value })}
+                      placeholder="https://ha.local:8123/api/webhook/prunerr"
+                      {...noAutofill}
+                    />
+                    <Input
+                      label="Signing secret (optional)"
+                      value={wh.secret || ''}
+                      onChange={(e) => handleWebhookChange(wh.id, { secret: e.target.value })}
+                      placeholder="Used to sign requests with X-Prunerr-Signature"
+                      {...noAutofill}
+                    />
+                  </div>
+                  <div className="flex flex-col items-end gap-3 pt-1">
+                    <ToggleSwitch
+                      checked={wh.enabled}
+                      onChange={(checked) => handleWebhookChange(wh.id, { enabled: checked })}
+                    />
+                    <button
+                      onClick={() => handleRemoveWebhook(wh.id)}
+                      className="p-1.5 rounded-lg text-surface-400 hover:text-ruby-400 hover:bg-ruby-500/10 transition-colors"
+                      title="Remove webhook"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-sm font-medium text-surface-300 mb-2">Events</p>
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                    {WEBHOOK_EVENTS.map((evt) => (
+                      <label key={evt.value} className="flex items-center gap-2 cursor-pointer group">
+                        <input
+                          type="checkbox"
+                          checked={wh.events.includes(evt.value)}
+                          onChange={() => handleToggleWebhookEvent(wh.id, evt.value)}
+                          className="w-4 h-4 rounded text-accent-500 bg-surface-800 border-surface-600 focus:ring-accent-500/50"
+                        />
+                        <span className="text-sm text-surface-300 group-hover:text-surface-50 transition-colors">
+                          {evt.label}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-4">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleTestWebhook(wh)}
+                    disabled={!wh.url || result.status === 'loading'}
+                  >
+                    {result.status === 'loading' ? (
+                      <>
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        Sending...
+                      </>
+                    ) : (
+                      <>
+                        <Webhook className="w-4 h-4" />
+                        Send test
+                      </>
+                    )}
+                  </Button>
+                  {result.status === 'success' && (
+                    <div className="flex items-center gap-2 text-emerald-400">
+                      <CheckCircle className="w-4 h-4" />
+                      <span className="text-sm">{result.message}</span>
+                    </div>
+                  )}
+                  {result.status === 'error' && (
+                    <div className="flex items-center gap-2 text-ruby-400">
+                      <XCircle className="w-4 h-4" />
+                      <span className="text-sm">{result.message}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+
+          <Button variant="outline" size="sm" onClick={handleAddWebhook}>
+            <Plus className="w-4 h-4" />
+            Add webhook
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Disk Pressure Reactive Mode */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-amber-500/10">
+              <Gauge className="w-5 h-5 text-amber-400" />
+            </div>
+            <div>
+              <CardTitle>Disk Pressure</CardTitle>
+              <CardDescription>
+                Keep free space above a target — reclaim the lowest-value content only when space runs low
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex items-center justify-between p-4 rounded-xl bg-surface-800/40 border border-surface-700/30">
+            <div>
+              <p className="font-medium text-surface-50">Enable reactive cleanup</p>
+              <p className="text-sm text-surface-400 mt-0.5">
+                Monitors real free space and acts only when below your target
+              </p>
+            </div>
+            <ToggleSwitch
+              checked={dp.enabled || false}
+              onChange={(checked) => handleDiskPressureChange('enabled', checked)}
+            />
+          </div>
+
+          {dp.enabled && (
+            <div className="pl-4 border-l-2 border-amber-500/30 space-y-5">
+              {/* Observe-only — prominent safety banner */}
+              <div className="flex items-center justify-between p-3 rounded-xl bg-amber-500/5 border border-amber-500/20">
+                <div className="flex items-start gap-2">
+                  <Eye className="w-4 h-4 text-amber-400 mt-0.5" />
+                  <div>
+                    <p className="font-medium text-surface-50">Observe-only mode</p>
+                    <p className="text-sm text-surface-400 mt-0.5">
+                      Non-destructive — logs and notifies what it <em>would</em> reclaim without deleting. Turn off to let Prunerr act.
+                    </p>
+                  </div>
+                </div>
+                <ToggleSwitch
+                  checked={dp.observeOnly ?? true}
+                  onChange={(checked) => handleDiskPressureChange('observeOnly', checked)}
+                />
+              </div>
+
+              {/* Monitored paths */}
+              <div>
+                <p className="text-sm font-medium text-surface-300 mb-2">Monitored paths</p>
+                <div className="space-y-2">
+                  {(dp.paths ?? []).map((path, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <input
+                        type="text"
+                        value={path}
+                        onChange={(e) => {
+                          const next = [...(dp.paths ?? [])];
+                          next[idx] = e.target.value;
+                          handleDiskPressureChange('paths', next);
+                        }}
+                        placeholder="/data/media"
+                        className="flex-1 px-3 py-2 rounded-lg bg-surface-800 border border-surface-600 text-surface-50 text-sm placeholder:text-surface-500 focus:outline-none focus:ring-2 focus:ring-accent-500/50"
+                      />
+                      <button
+                        onClick={() => handleDiskPressureChange('paths', (dp.paths ?? []).filter((_, i) => i !== idx))}
+                        className="p-2 rounded-lg text-surface-400 hover:text-ruby-400 hover:bg-ruby-500/10 transition-colors"
+                        title="Remove path"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  ))}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleDiskPressureChange('paths', [...(dp.paths ?? []), ''])}
+                  >
+                    <Plus className="w-4 h-4" />
+                    Add path
+                  </Button>
+                </div>
+              </div>
+
+              {/* Target */}
+              <div>
+                <p className="text-sm font-medium text-surface-300 mb-2">Keep free</p>
+                <div className="flex items-center gap-3">
+                  <div className="flex rounded-lg overflow-hidden border border-surface-600">
+                    {(['percent', 'absolute'] as const).map((mode) => (
+                      <button
+                        key={mode}
+                        onClick={() => handleDiskPressureChange('targetMode', mode)}
+                        className={cn(
+                          'px-3 py-2 text-sm transition-colors',
+                          (dp.targetMode ?? 'percent') === mode
+                            ? 'bg-accent-500 text-surface-900 font-medium'
+                            : 'bg-surface-800 text-surface-300 hover:bg-surface-700'
+                        )}
+                      >
+                        {mode === 'percent' ? '% of disk' : 'GB'}
+                      </button>
+                    ))}
+                  </div>
+                  <input
+                    type="number"
+                    min={0}
+                    value={dp.targetValue ?? 10}
+                    onChange={(e) => handleDiskPressureChange('targetValue', Number(e.target.value))}
+                    className="w-24 px-3 py-2 rounded-lg bg-surface-800 border border-surface-600 text-surface-50 text-sm focus:outline-none focus:ring-2 focus:ring-accent-500/50"
+                  />
+                  <span className="text-sm text-surface-400">soft target</span>
+                </div>
+                <div className="flex items-center gap-3 mt-2">
+                  <input
+                    type="number"
+                    min={0}
+                    value={dp.criticalValue ?? 5}
+                    onChange={(e) => handleDiskPressureChange('criticalValue', Number(e.target.value))}
+                    className="w-24 px-3 py-2 rounded-lg bg-surface-800 border border-surface-600 text-surface-50 text-sm focus:outline-none focus:ring-2 focus:ring-accent-500/50"
+                  />
+                  <span className="text-sm text-surface-400">
+                    critical threshold ({dp.targetMode === 'absolute' ? 'GB' : '%'}) — below this, reclaim with no grace
+                  </span>
+                </div>
+              </div>
+
+              {/* Numeric knobs */}
+              <div className="grid grid-cols-2 gap-4">
+                <Input
+                  label="Buffer (GB)"
+                  type="number"
+                  value={String(dp.bufferGb ?? 50)}
+                  onChange={(e) => handleDiskPressureChange('bufferGb', Number(e.target.value))}
+                />
+                <Input
+                  label="Check interval (min)"
+                  type="number"
+                  value={String(dp.intervalMinutes ?? 20)}
+                  onChange={(e) => handleDiskPressureChange('intervalMinutes', Number(e.target.value))}
+                />
+                <Input
+                  label="Soft grace (days)"
+                  type="number"
+                  value={String(dp.softGraceDays ?? 7)}
+                  onChange={(e) => handleDiskPressureChange('softGraceDays', Number(e.target.value))}
+                />
+                <Input
+                  label="Max items per run"
+                  type="number"
+                  value={String(dp.maxItemsPerRun ?? 25)}
+                  onChange={(e) => handleDiskPressureChange('maxItemsPerRun', Number(e.target.value))}
+                />
+                <Input
+                  label="Max GB per run"
+                  type="number"
+                  value={String(dp.maxGbPerRun ?? 500)}
+                  onChange={(e) => handleDiskPressureChange('maxGbPerRun', Number(e.target.value))}
+                />
+                <Input
+                  label="Unwatched threshold (days)"
+                  type="number"
+                  value={String(dp.unwatchedDays ?? 90)}
+                  onChange={(e) => handleDiskPressureChange('unwatchedDays', Number(e.target.value))}
+                />
+              </div>
+
+              {/* Deletion action */}
+              <div>
+                <p className="text-sm font-medium text-surface-300 mb-2">Deletion action</p>
+                <select
+                  value={dp.deletionAction ?? 'unmonitor_and_delete'}
+                  onChange={(e) => handleDiskPressureChange('deletionAction', e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg bg-surface-800 border border-surface-600 text-surface-50 text-sm focus:outline-none focus:ring-2 focus:ring-accent-500/50"
+                >
+                  {DELETION_ACTION_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Critical auto-process */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-surface-300">Auto-delete immediately on critical pressure</p>
+                  <p className="text-xs text-surface-500 mt-0.5">
+                    Bypasses the grace period when critically low. Protected items are always skipped.
+                  </p>
+                </div>
+                <ToggleSwitch
+                  checked={dp.criticalAutoProcess ?? false}
+                  onChange={(checked) => handleDiskPressureChange('criticalAutoProcess', checked)}
+                />
               </div>
             </div>
           )}

--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -10,6 +10,7 @@ import {
   activityApi,
   healthApi,
   scanApi,
+  webhooksApi,
 } from '@/services/api';
 import type {
   LibraryFilters,
@@ -364,6 +365,12 @@ export function useSaveSettings() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings });
     },
+  });
+}
+
+export function useTestWebhook() {
+  return useMutation({
+    mutationFn: (body: { url: string; secret?: string; event?: string }) => webhooksApi.test(body),
   });
 }
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -556,4 +556,15 @@ export const settingsApi = {
   },
 };
 
+// Webhook APIs
+export const webhooksApi = {
+  test: async (body: { url: string; secret?: string; event?: string }): Promise<{ status?: number }> => {
+    const { data } = await api.post<ApiResponse<{ status?: number }> & { message?: string }>(
+      '/webhooks/test',
+      body
+    );
+    return data.data ?? {};
+  },
+};
+
 export default api;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -206,6 +206,16 @@ export interface DashboardStats {
   activeRules: number;
   collectionCount: number;
   protectedCollections: number;
+
+  // Disk-pressure / real free space (best-effort; null when unreadable)
+  diskPressureEnabled?: boolean;
+  diskObserveOnly?: boolean;
+  diskFreeBytes?: number | null;
+  diskTotalBytes?: number | null;
+  diskUsedBytes?: number | null;
+  diskTargetBytes?: number | null;
+  diskCriticalBytes?: number | null;
+  diskPressureSeverity?: 'ok' | 'soft' | 'critical' | null;
 }
 
 export interface UpcomingDeletion {
@@ -321,6 +331,46 @@ export interface Settings {
   watchHistory?: { provider?: string; lookback_days?: string };
   exclusionPatterns?: Array<{ field: string; operator: string; value: string }>;
   excludedLibraryKeys?: string[];
+  webhooks?: WebhookTarget[];
+  diskPressure?: DiskPressureSettings;
+}
+
+// Events a webhook target / notification can opt into. Mirrors the server
+// NotificationEvent union.
+export type NotificationEventName =
+  | 'ITEMS_MARKED'
+  | 'DELETION_IMMINENT'
+  | 'DELETION_COMPLETE'
+  | 'SCAN_COMPLETE'
+  | 'SCAN_ERROR'
+  | 'DELETION_ERROR'
+  | 'DISK_PRESSURE_TRIGGERED';
+
+export interface WebhookTarget {
+  id: string;
+  name?: string;
+  url: string;
+  events: NotificationEventName[];
+  enabled: boolean;
+  secret?: string;
+}
+
+export interface DiskPressureSettings {
+  enabled?: boolean;
+  observeOnly?: boolean;
+  paths?: string[];
+  targetMode?: 'percent' | 'absolute';
+  targetValue?: number;
+  criticalValue?: number;
+  bufferGb?: number;
+  softGraceDays?: number;
+  criticalGraceDays?: number;
+  criticalAutoProcess?: boolean;
+  deletionAction?: string;
+  maxItemsPerRun?: number;
+  maxGbPerRun?: number;
+  intervalMinutes?: number;
+  unwatchedDays?: number;
 }
 
 // Unraid Types

--- a/docs/home-assistant.md
+++ b/docs/home-assistant.md
@@ -1,0 +1,136 @@
+# Home Assistant Integration
+
+Prunerr integrates with Home Assistant three ways, no custom component required:
+
+1. **Outbound webhooks** — Prunerr POSTs events to HA, which become automation triggers.
+2. **REST sensors** — HA pulls live state (free space, pending deletions) from `/api/stats`.
+3. **REST commands** — HA triggers a scan via `/api/scan/trigger`.
+
+Together these let HA be your notification layer (TTS on speakers, phone push, dashboard cards) and react to disk-pressure events — reaching people on the devices they actually use.
+
+> **Auth:** All `/api/*` routes accept an `X-Api-Key` header. Find/regenerate the key under **Settings → API Key** in Prunerr. Requests from the web UI bypass the key (same-origin), but HA must always send it. Replace `http://prunerr.local:3000` and `YOUR_API_KEY` below with your values.
+
+---
+
+## 1. Receive Prunerr events (webhooks → automation triggers)
+
+In Prunerr, go to **Settings → Outbound Webhooks → Add webhook** and point it at an HA webhook URL:
+
+```
+http://homeassistant.local:8123/api/webhook/prunerr-events
+```
+
+Tick the events you care about (e.g. **Disk pressure**, **Deletion complete**). Optionally set a **signing secret** — Prunerr then sends an `X-Prunerr-Signature: sha256=<hmac>` header computed over the exact request body, which you can verify.
+
+### Payload shape
+
+Every webhook POST is a JSON envelope:
+
+```json
+{
+  "event": "DISK_PRESSURE_TRIGGERED",
+  "timestamp": "2026-05-30T03:20:00.000Z",
+  "source": "prunerr",
+  "version": 1,
+  "data": {
+    "severity": "soft",
+    "path": "/data/media",
+    "freeBytes": 850000000000,
+    "totalBytes": 12000000000000,
+    "targetBytes": 1000000000000,
+    "deficitBytes": 150000000000,
+    "observeOnly": false,
+    "itemsQueued": 1,
+    "projectedReclaimBytes": 64000000000,
+    "items": [{ "id": 1, "title": "Example Movie", "type": "movie", "sizeBytes": 64000000000 }]
+  }
+}
+```
+
+Also sent as headers: `X-Prunerr-Event: <EVENT_NAME>` and (if a secret is set) `X-Prunerr-Signature`.
+
+### Example automation
+
+```yaml
+automation:
+  - alias: "Prunerr disk pressure → announce"
+    trigger:
+      - platform: webhook
+        webhook_id: prunerr-events
+        allowed_methods: [POST]
+        local_only: true
+    condition:
+      - condition: template
+        value_template: "{{ trigger.json.event == 'DISK_PRESSURE_TRIGGERED' }}"
+    action:
+      - service: notify.mobile_app_my_phone
+        data:
+          title: "Prunerr: {{ trigger.json.data.severity }} disk pressure"
+          message: >
+            {{ trigger.json.data.path }} is low.
+            {{ trigger.json.data.itemsQueued }} item(s) queued
+            (~{{ (trigger.json.data.projectedReclaimBytes / 1024**3) | round(0) }} GB).
+```
+
+---
+
+## 2. Pull Prunerr state (REST sensors)
+
+Add to `configuration.yaml`. The disk fields are populated when **Disk Pressure** is enabled with at least one monitored path; otherwise they are `null`.
+
+```yaml
+rest:
+  - resource: "http://prunerr.local:3000/api/stats"
+    scan_interval: 300
+    headers:
+      X-Api-Key: "YOUR_API_KEY"
+    sensor:
+      - name: "Prunerr Free Space"
+        value_template: "{{ value_json.data.diskFreeBytes | int(0) }}"
+        device_class: data_size
+        unit_of_measurement: "B"
+      - name: "Prunerr Disk Pressure"
+        value_template: "{{ value_json.data.diskPressureSeverity | default('ok') }}"
+      - name: "Prunerr Pending Deletions"
+        value_template: "{{ value_json.data.itemsMarkedForDeletion | int(0) }}"
+      - name: "Prunerr Reclaimable Space"
+        value_template: "{{ value_json.data.reclaimableSpace | int(0) }}"
+        device_class: data_size
+        unit_of_measurement: "B"
+```
+
+---
+
+## 3. Trigger a scan (REST command)
+
+```yaml
+rest_command:
+  prunerr_scan:
+    url: "http://prunerr.local:3000/api/scan/trigger"
+    method: POST
+    headers:
+      X-Api-Key: "YOUR_API_KEY"
+```
+
+`POST /api/scan/trigger` returns **202** when a scan starts and **409** if one is already running — both are normal; HA's `rest_command` treats any 2xx/4xx without raising unless you check the response.
+
+Use it from an automation, e.g. run a scan when free space drops:
+
+```yaml
+automation:
+  - alias: "Prunerr scan when disk fills"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.prunerr_free_space
+        below: 1099511627776  # 1 TiB
+    action:
+      - service: rest_command.prunerr_scan
+```
+
+---
+
+## Notes
+
+- Free space is read directly from the filesystem (`statfs`) on the paths configured under **Settings → Disk Pressure**, so it works without Unraid.
+- Webhook delivery is fire-and-forget with up to 3 retries on transient failures (5xx / network / 429); it never blocks Prunerr's own processing.
+- All byte fields are raw bytes — divide by `1024**3` for GB or `1024**4` for TB in templates.

--- a/server/src/db/repositories/activity.ts
+++ b/server/src/db/repositories/activity.ts
@@ -6,7 +6,7 @@ import logger from '../../utils/logger';
 // ============================================================================
 
 // Event types that can be logged
-export type ActivityEventType = 'scan' | 'deletion' | 'rule_match' | 'protection' | 'manual_action' | 'error';
+export type ActivityEventType = 'scan' | 'deletion' | 'rule_match' | 'protection' | 'manual_action' | 'error' | 'disk_pressure';
 
 // Actor types that can perform actions
 export type ActivityActorType = 'scheduler' | 'user' | 'rule';

--- a/server/src/notifications/__tests__/webhooks.test.ts
+++ b/server/src/notifications/__tests__/webhooks.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'crypto';
+
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const getJsonMock = vi.fn();
+vi.mock('../../db/repositories/settings', () => ({
+  default: { getJson: (key: string, def: unknown) => getJsonMock(key, def) },
+}));
+
+import { sendWebhook, fanOutWebhooks, type WebhookEnvelope } from '../webhooks';
+
+const envelope: WebhookEnvelope = {
+  event: 'DELETION_COMPLETE',
+  timestamp: '2026-05-30T00:00:00.000Z',
+  source: 'prunerr',
+  version: 1,
+  data: { itemsDeleted: 2 },
+};
+
+describe('sendWebhook', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getJsonMock.mockReset();
+  });
+
+  it('POSTs the envelope with the event header and succeeds on 2xx', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    const result = await sendWebhook({ url: 'http://hook.test/x' }, envelope);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe(204);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0]!;
+    const headers = init!.headers as Record<string, string>;
+    expect(headers['X-Prunerr-Event']).toBe('DELETION_COMPLETE');
+    expect(headers['X-Prunerr-Signature']).toBeUndefined();
+    expect(JSON.parse(init!.body as string)).toMatchObject({ event: 'DELETION_COMPLETE', source: 'prunerr' });
+  });
+
+  it('signs the exact body with HMAC-SHA256 when a secret is set', async () => {
+    let capturedBody = '';
+    vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+      capturedBody = (init!.body as string);
+      return new Response(null, { status: 200 });
+    });
+
+    const secret = 'topsecret';
+    await sendWebhook({ url: 'http://hook.test/x', secret }, envelope);
+
+    const expected = `sha256=${crypto.createHmac('sha256', secret).update(capturedBody).digest('hex')}`;
+    const fetchSpy = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const headers = fetchSpy.mock.calls[0]![1].headers as Record<string, string>;
+    expect(headers['X-Prunerr-Signature']).toBe(expected);
+  });
+
+  it('does NOT retry on 4xx', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('bad', { status: 400 }));
+    const result = await sendWebhook({ url: 'http://hook.test/x' }, envelope, 3);
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(400);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 5xx up to the attempt limit', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('err', { status: 503 }));
+    const result = await sendWebhook({ url: 'http://hook.test/x' }, envelope, 3);
+    expect(result.success).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('fanOutWebhooks', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getJsonMock.mockReset();
+  });
+
+  it('only posts to enabled targets that opted into the event', async () => {
+    getJsonMock.mockReturnValue([
+      { id: 'a', url: 'http://a.test', enabled: true, events: ['DELETION_COMPLETE'] },
+      { id: 'b', url: 'http://b.test', enabled: true, events: ['SCAN_COMPLETE'] }, // wrong event
+      { id: 'c', url: 'http://c.test', enabled: false, events: ['DELETION_COMPLETE'] }, // disabled
+    ]);
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
+
+    await fanOutWebhooks('DELETION_COMPLETE', { itemsDeleted: 1 }, '2026-05-30T00:00:00.000Z');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]![0]).toBe('http://a.test');
+  });
+
+  it('no-ops when no targets match', async () => {
+    getJsonMock.mockReturnValue([]);
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
+    await fanOutWebhooks('DELETION_COMPLETE', {}, '2026-05-30T00:00:00.000Z');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/notifications/index.ts
+++ b/server/src/notifications/index.ts
@@ -8,6 +8,7 @@ import {
   getPlainTextMessage,
   getDiscordMessage,
 } from './templates';
+import { fanOutWebhooks } from './webhooks';
 
 // ============================================================================
 // Types
@@ -54,37 +55,46 @@ export class NotificationService {
   async notify(event: NotificationEvent | string, data: NotificationData): Promise<NotificationResult[]> {
     logger.info(`Sending notification for event: ${event}`);
 
-    // Check per-event notification preferences
     const notificationEvent = event as NotificationEvent;
-    if (!this.isEventEnabled(notificationEvent)) {
-      logger.info(`Notification for ${event} suppressed by user preference`);
-      return [];
+    const results: NotificationResult[] = [];
+    // One timestamp shared by Discord embeds and the webhook envelope.
+    const timestamp = new Date().toISOString();
+
+    // --- Discord: gated by the per-event preference + Discord config ---
+    // (Webhook targets carry their own per-event opt-in, so the preference
+    // gate must NOT short-circuit the whole method.)
+    if (this.isEventEnabled(notificationEvent)) {
+      const discordEnabled = settingsRepo.getBoolean('notifications_discordEnabled', false);
+      const discordWebhook = settingsRepo.getValue('notifications_discordWebhook');
+
+      if (discordEnabled && discordWebhook) {
+        try {
+          const message = getDiscordMessage(notificationEvent, data);
+          const result = await this.sendDiscord(discordWebhook, message);
+          results.push({
+            channel: 'discord',
+            success: result,
+            error: result ? undefined : 'Failed to send Discord message',
+          });
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          logger.error('Discord notification error:', error);
+          results.push({
+            channel: 'discord',
+            success: false,
+            error: errorMessage,
+          });
+        }
+      }
+    } else {
+      logger.info(`Discord notification for ${event} suppressed by user preference`);
     }
 
-    const results: NotificationResult[] = [];
-
-    // Send Discord notification - read settings at notification time
-    const discordEnabled = settingsRepo.getBoolean('notifications_discordEnabled', false);
-    const discordWebhook = settingsRepo.getValue('notifications_discordWebhook');
-
-    if (discordEnabled && discordWebhook) {
-      try {
-        const message = getDiscordMessage(notificationEvent, data);
-        const result = await this.sendDiscord(discordWebhook, message);
-        results.push({
-          channel: 'discord',
-          success: result,
-          error: result ? undefined : 'Failed to send Discord message',
-        });
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.error('Discord notification error:', error);
-        results.push({
-          channel: 'discord',
-          success: false,
-          error: errorMessage,
-        });
-      }
+    // --- Outbound webhooks: independent per-target opt-in, fire-and-forget ---
+    try {
+      await fanOutWebhooks(notificationEvent, data, timestamp);
+    } catch (error) {
+      logger.error('Webhook fan-out error:', error);
     }
 
     // Log summary
@@ -121,6 +131,9 @@ export class NotificationService {
       case 'DELETION_COMPLETE':
       case 'DELETION_ERROR': {
         return settingsRepo.getBoolean('notifications_notifyOnDeletion', true);
+      }
+      case 'DISK_PRESSURE_TRIGGERED': {
+        return settingsRepo.getBoolean('notifications_notifyOnDiskPressure', true);
       }
       default:
         return true;

--- a/server/src/notifications/templates.ts
+++ b/server/src/notifications/templates.ts
@@ -80,6 +80,29 @@ export interface DeletionErrorData {
   timestamp: string;
 }
 
+export interface DiskPressureData {
+  severity: 'soft' | 'critical';
+  /** The breached filesystem path that triggered this event */
+  path: string;
+  freeBytes: number;
+  totalBytes: number;
+  targetBytes: number;
+  /** How far below the target we are (targetBytes - freeBytes), >= 0 */
+  deficitBytes: number;
+  /** When true, nothing was queued; the items below are what *would* be reclaimed */
+  observeOnly: boolean;
+  itemsQueued: number;
+  projectedReclaimBytes: number;
+  deletionAction: string;
+  items: Array<{
+    id: number;
+    title: string;
+    type: string;
+    sizeBytes: number;
+  }>;
+  timestamp: string;
+}
+
 // ============================================================================
 // Discord Message Types
 // ============================================================================
@@ -144,6 +167,21 @@ function formatDuration(ms: number): string {
 function discordTimestamp(date: string | Date, style: 'R' | 'f' | 'F' | 'D' | 't' | 'T' | 'd' = 'R'): string {
   const unix = Math.floor(new Date(date).getTime() / 1000);
   return `<t:${unix}:${style}>`;
+}
+
+/**
+ * Format a byte count to a human-readable string (e.g. "1.2 TB", "640 GB")
+ */
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes < 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  let value = bytes;
+  let i = 0;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i++;
+  }
+  return `${value >= 100 || i === 0 ? Math.round(value) : value.toFixed(1)} ${units[i]}`;
 }
 
 // ============================================================================
@@ -291,6 +329,43 @@ export function getDeletionErrorText(data: DeletionErrorData): string {
     `Items processed before error: ${data.itemsProcessedBeforeError}\n` +
     `Time: ${new Date(data.timestamp).toLocaleString()}`
   );
+}
+
+/**
+ * Generate plain text message for a disk-pressure event
+ */
+export function getDiskPressureText(data: DiskPressureData): string {
+  const action = data.observeOnly
+    ? 'would be queued for deletion'
+    : data.itemsQueued > 0
+      ? 'queued for deletion'
+      : 'flagged';
+  const header = data.severity === 'critical' ? '⚠️ CRITICAL: ' : '';
+  const itemList = data.items
+    .slice(0, 10)
+    .map((item) => `  - ${item.title} (${item.type}, ${formatBytes(item.sizeBytes)})`)
+    .join('\n');
+
+  let msg =
+    `${header}[Prunerr] Disk Pressure on ${data.path}\n\n` +
+    `Free: ${formatBytes(data.freeBytes)} of ${formatBytes(data.totalBytes)} ` +
+    `(target: ${formatBytes(data.targetBytes)}, short by ${formatBytes(data.deficitBytes)})\n`;
+
+  if (data.items.length > 0) {
+    msg +=
+      `\n${data.observeOnly ? data.items.length : data.itemsQueued} item${
+        (data.observeOnly ? data.items.length : data.itemsQueued) !== 1 ? 's' : ''
+      } ${action} ` +
+      `(~${formatBytes(data.projectedReclaimBytes)}):\n${itemList}\n` +
+      (data.items.length > 10 ? `  ... and ${data.items.length - 10} more\n` : '');
+  } else {
+    msg += `\nNo eligible items found to reclaim.\n`;
+  }
+
+  if (data.observeOnly) {
+    msg += `\nObserve-only mode is on — nothing was deleted.`;
+  }
+  return msg.trimEnd();
 }
 
 // ============================================================================
@@ -572,6 +647,70 @@ export function getDeletionErrorDiscord(data: DeletionErrorData): DiscordMessage
   return { embeds: [embed], username: 'Prunerr', avatar_url: AVATAR_URL };
 }
 
+/**
+ * Generate Discord message for a disk-pressure event
+ */
+export function getDiskPressureDiscord(data: DiskPressureData): DiscordMessage {
+  const isCritical = data.severity === 'critical';
+  const emoji = isCritical ? '\u{1F6A8}' : '\u{1F4BE}'; // 🚨 / 💾
+  const verb = data.observeOnly
+    ? 'would be reclaimed'
+    : data.itemsQueued > 0
+      ? 'queued for deletion'
+      : 'flagged';
+
+  const embed: DiscordEmbed = {
+    title: `${emoji} ${isCritical ? 'Critical Disk Pressure' : 'Disk Pressure'} — ${formatBytes(data.freeBytes)} free`,
+    color: isCritical ? COLORS.ERROR : COLORS.WARNING,
+    description: `**${data.path}** is below its ${isCritical ? 'critical' : 'target'} threshold (${formatBytes(
+      data.targetBytes
+    )}). Short by **${formatBytes(data.deficitBytes)}**.`,
+    timestamp: data.timestamp,
+    footer: { text: 'Prunerr' },
+    fields: [
+      { name: 'Free', value: formatBytes(data.freeBytes), inline: true },
+      { name: 'Total', value: formatBytes(data.totalBytes), inline: true },
+      {
+        name: data.observeOnly ? 'Would Reclaim' : 'Projected Reclaim',
+        value: `~${formatBytes(data.projectedReclaimBytes)}`,
+        inline: true,
+      },
+    ],
+  };
+
+  if (data.items.length > 0) {
+    const shown = data.items.slice(0, 10);
+    let value = shown.map((i) => `• ${i.title} (${formatBytes(i.sizeBytes)})`).join('\n');
+    if (data.items.length > shown.length) {
+      value += `\n... and ${data.items.length - shown.length} more`;
+    }
+    embed.fields!.push({
+      name: `${data.observeOnly ? data.items.length : data.itemsQueued} item${
+        (data.observeOnly ? data.items.length : data.itemsQueued) !== 1 ? 's' : ''
+      } ${verb}`,
+      value: value.length > 1024 ? `${value.slice(0, 1020)}…` : value,
+      inline: false,
+    });
+  } else {
+    embed.fields!.push({ name: 'Items', value: 'No eligible items found to reclaim.', inline: false });
+  }
+
+  if (data.observeOnly) {
+    embed.fields!.push({
+      name: '\u{1F441}️ Observe-only',
+      value: 'Nothing was deleted. Turn off observe-only to let Prunerr reclaim automatically.',
+      inline: false,
+    });
+  }
+
+  return {
+    content: isCritical && !data.observeOnly ? '@here' : undefined,
+    embeds: [embed],
+    username: 'Prunerr',
+    avatar_url: AVATAR_URL,
+  };
+}
+
 // ============================================================================
 // Template Selector Functions
 // ============================================================================
@@ -582,7 +721,8 @@ export type NotificationEvent =
   | 'DELETION_COMPLETE'
   | 'SCAN_COMPLETE'
   | 'SCAN_ERROR'
-  | 'DELETION_ERROR';
+  | 'DELETION_ERROR'
+  | 'DISK_PRESSURE_TRIGGERED';
 
 /**
  * Get plain text message for any notification event
@@ -601,6 +741,8 @@ export function getPlainTextMessage(event: NotificationEvent, data: Notification
       return getScanErrorText(data as unknown as ScanErrorData);
     case 'DELETION_ERROR':
       return getDeletionErrorText(data as unknown as DeletionErrorData);
+    case 'DISK_PRESSURE_TRIGGERED':
+      return getDiskPressureText(data as unknown as DiskPressureData);
     default:
       return `[Prunerr] Notification: ${event}`;
   }
@@ -623,6 +765,8 @@ export function getDiscordMessage(event: NotificationEvent, data: NotificationDa
       return getScanErrorDiscord(data as unknown as ScanErrorData);
     case 'DELETION_ERROR':
       return getDeletionErrorDiscord(data as unknown as DeletionErrorData);
+    case 'DISK_PRESSURE_TRIGGERED':
+      return getDiskPressureDiscord(data as unknown as DiskPressureData);
     default:
       return { content: `[Prunerr] ${event}`, username: 'Prunerr', avatar_url: AVATAR_URL };
   }

--- a/server/src/notifications/webhooks.ts
+++ b/server/src/notifications/webhooks.ts
@@ -1,0 +1,166 @@
+import crypto from 'crypto';
+import logger from '../utils/logger';
+import settingsRepo from '../db/repositories/settings';
+import type { NotificationData, NotificationEvent } from './templates';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface WebhookTarget {
+  id: string;
+  name?: string;
+  url: string;
+  /** Events this target opts into. Empty array = no events (effectively off). */
+  events: NotificationEvent[];
+  enabled: boolean;
+  /** Optional shared secret; when set, requests are signed with HMAC-SHA256. */
+  secret?: string;
+}
+
+export interface WebhookEnvelope {
+  event: NotificationEvent | string;
+  timestamp: string;
+  source: 'prunerr';
+  version: 1;
+  data: NotificationData;
+}
+
+const SETTINGS_KEY = 'webhooks_targets';
+const TIMEOUT_MS = 10_000;
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAYS_MS = [500, 1500];
+
+// ============================================================================
+// Loading
+// ============================================================================
+
+/**
+ * Load configured webhook targets from settings. Tolerates malformed data.
+ */
+export function loadWebhookTargets(): WebhookTarget[] {
+  const raw = settingsRepo.getJson<WebhookTarget[]>(SETTINGS_KEY, []);
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((t) => t && typeof t.url === 'string' && t.url.length > 0);
+}
+
+// ============================================================================
+// Sending
+// ============================================================================
+
+function sign(secret: string, body: string): string {
+  return `sha256=${crypto.createHmac('sha256', secret).update(body).digest('hex')}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface WebhookSendResult {
+  success: boolean;
+  status?: number;
+  error?: string;
+}
+
+/**
+ * POST a single envelope to a webhook target. Retries on network errors,
+ * 5xx, and 429 (never on other 4xx). Never throws.
+ *
+ * @param attempts override the max attempt count (e.g. 1 for the Test button)
+ */
+export async function sendWebhook(
+  target: Pick<WebhookTarget, 'url' | 'secret' | 'name'>,
+  envelope: WebhookEnvelope,
+  attempts: number = MAX_ATTEMPTS
+): Promise<WebhookSendResult> {
+  if (!target.url) {
+    return { success: false, error: 'Webhook URL not configured' };
+  }
+
+  // Serialize once so the signature matches the exact bytes we send.
+  const body = JSON.stringify(envelope);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'Prunerr-Webhook/1',
+    'X-Prunerr-Event': String(envelope.event),
+  };
+  if (target.secret) {
+    headers['X-Prunerr-Signature'] = sign(target.secret, body);
+  }
+
+  let lastError = '';
+  let lastStatus: number | undefined;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+      const response = await fetch(target.url, {
+        method: 'POST',
+        headers,
+        body,
+        signal: controller.signal,
+        // Do NOT follow redirects: a target must not be able to bounce us into
+        // an internal endpoint (SSRF). A 3xx surfaces as an opaqueredirect.
+        redirect: 'manual',
+      });
+      lastStatus = response.status;
+
+      // redirect:'manual' yields an opaque response (status 0) for any 3xx.
+      if (response.type === 'opaqueredirect' || response.status === 0) {
+        clearTimeout(timer);
+        return { success: false, error: 'Webhook target attempted a redirect, which is not followed' };
+      }
+
+      if (response.ok) {
+        return { success: true, status: response.status };
+      }
+
+      // 4xx (except 429) are client errors that won't be fixed by retrying.
+      const retryable = response.status >= 500 || response.status === 429;
+      lastError = `HTTP ${response.status}`;
+      if (!retryable) {
+        return { success: false, status: response.status, error: lastError };
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (attempt < attempts) {
+      await sleep(RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)]!);
+    }
+  }
+
+  logger.warn(`Webhook to ${target.name || target.url} failed after ${attempts} attempt(s): ${lastError}`);
+  return { success: false, status: lastStatus, error: lastError };
+}
+
+/**
+ * Fan an event out to every enabled target that opted into it. Fire-and-forget:
+ * builds one envelope, posts to all matching targets in parallel, never throws.
+ */
+export async function fanOutWebhooks(
+  event: NotificationEvent | string,
+  data: NotificationData,
+  timestamp: string
+): Promise<void> {
+  const targets = loadWebhookTargets().filter(
+    (t) => t.enabled && Array.isArray(t.events) && t.events.includes(event as NotificationEvent)
+  );
+
+  if (targets.length === 0) return;
+
+  const envelope: WebhookEnvelope = {
+    event,
+    timestamp,
+    source: 'prunerr',
+    version: 1,
+    data,
+  };
+
+  const results = await Promise.allSettled(targets.map((t) => sendWebhook(t, envelope)));
+  const ok = results.filter((r) => r.status === 'fulfilled' && r.value.success).length;
+  logger.info(`Webhook fan-out for ${event}: ${ok}/${targets.length} delivered`);
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -12,6 +12,7 @@ import historyRouter from './history';
 import unraidRouter from './unraid';
 import usersRouter from './users';
 import collectionsRouter from './collections';
+import webhooksRouter from './webhooks';
 
 const router = Router();
 
@@ -29,5 +30,6 @@ router.use('/history', historyRouter);
 router.use('/unraid', unraidRouter);
 router.use('/users', usersRouter);
 router.use('/collections', collectionsRouter);
+router.use('/webhooks', webhooksRouter);
 
 export default router;

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -7,7 +7,7 @@ import { getApiKey, clearApiKeyCache, ensureApiKey } from '../middleware/apiAuth
 import crypto from 'crypto';
 import { PlexService, TautulliService, SonarrService, RadarrService, OverseerrService, UnraidService } from '../services';
 import { TracearrService } from '../services/tracearr';
-import { refreshServices, initializeServices } from '../services/init';
+import { refreshServices, initializeServices, applyDiskPressureSchedule } from '../services/init';
 import { getScheduler } from '../scheduler';
 import { getNotificationService } from '../notifications';
 
@@ -37,6 +37,8 @@ const KNOWN_SETTING_PREFIXES = [
   'exclusion_',
   'excluded_library_',
   'watch_history_',
+  'webhooks_',
+  'diskPressure_',
   'api_key',
 ];
 
@@ -73,8 +75,10 @@ router.get('/', (_req: Request, res: Response) => {
     const plexSync: Record<string, string | boolean | number> = {};
     const display: Record<string, string> = {};
     const watchHistory: Record<string, string> = {};
+    const diskPressure: Record<string, string | boolean | number | string[]> = {};
     let exclusionPatterns: unknown[] = [];
     let excludedLibraryKeys: string[] = [];
+    let webhooks: unknown[] = [];
 
     for (const setting of rawSettings) {
       const { key, value } = setting;
@@ -92,6 +96,33 @@ router.get('/', (_req: Request, res: Response) => {
         try {
           excludedLibraryKeys = JSON.parse(value);
         } catch { /* empty */ }
+        continue;
+      }
+
+      // Parse outbound webhook targets (stored as a single JSON array)
+      if (key === 'webhooks_targets') {
+        try {
+          webhooks = JSON.parse(value);
+        } catch { /* empty */ }
+        continue;
+      }
+
+      // Parse disk-pressure settings
+      if (key.startsWith('diskPressure_')) {
+        const field = key.replace('diskPressure_', '');
+        if (field === 'paths') {
+          try {
+            diskPressure[field] = JSON.parse(value);
+          } catch {
+            diskPressure[field] = [];
+          }
+        } else if (value === 'true' || value === 'false') {
+          diskPressure[field] = value === 'true';
+        } else if (value !== '' && !isNaN(Number(value))) {
+          diskPressure[field] = Number(value);
+        } else {
+          diskPressure[field] = value;
+        }
         continue;
       }
 
@@ -164,8 +195,10 @@ router.get('/', (_req: Request, res: Response) => {
         plexSync,
         display,
         watchHistory,
+        diskPressure,
         exclusionPatterns,
         excludedLibraryKeys,
+        webhooks,
       },
     });
   } catch (error) {
@@ -432,6 +465,26 @@ router.put('/', async (req: Request, res: Response) => {
       }
     }
 
+    // Save outbound webhook targets (stored as a single JSON array)
+    if (settings.webhooks !== undefined) {
+      const value = JSON.stringify(Array.isArray(settings.webhooks) ? settings.webhooks : []);
+      settingsRepo.set({ key: 'webhooks_targets', value });
+      savedSettings.push({ key: 'webhooks_targets', value });
+    }
+
+    // Save disk-pressure configuration
+    if (settings.diskPressure) {
+      for (const [field, value] of Object.entries(settings.diskPressure)) {
+        if (value !== undefined && value !== null) {
+          const key = `diskPressure_${field}`;
+          // `paths` is an array — store as JSON; everything else as a string
+          const stored = field === 'paths' ? JSON.stringify(value) : String(value);
+          settingsRepo.set({ key, value: stored });
+          savedSettings.push({ key, value: stored });
+        }
+      }
+    }
+
     // Update scheduler if schedule or Plex sync settings were changed
     const hasScheduleSettings = savedSettings.some(
       s => s.key.startsWith('schedule_') || s.key.startsWith('plexSync_')
@@ -522,6 +575,16 @@ router.put('/', async (req: Request, res: Response) => {
       } catch (error) {
         logger.error('Failed to update scheduler:', error);
         // Don't fail the request - settings are saved, scheduler will pick up on next cycle
+      }
+    }
+
+    // Apply disk-pressure schedule changes (enable/disable + interval)
+    if (savedSettings.some((s) => s.key.startsWith('diskPressure_'))) {
+      try {
+        applyDiskPressureSchedule();
+      } catch (error) {
+        logger.error('Failed to update disk-pressure schedule:', error);
+        // Settings are saved; scheduler picks up on next restart regardless.
       }
     }
 

--- a/server/src/routes/stats.ts
+++ b/server/src/routes/stats.ts
@@ -4,12 +4,91 @@ import mediaItemsRepo from '../db/repositories/mediaItems';
 import collectionsRepo from '../db/repositories/collections';
 import rulesRepo from '../db/repositories/rules';
 import storageSnapshotsRepo from '../db/repositories/storageSnapshots';
+import settingsRepo from '../db/repositories/settings';
+import { getUsageForPaths, resolveTargetBytes, type FsUsage, type TargetMode } from '../services/diskSpace';
 import logger from '../utils/logger';
 
 const router = Router();
 
+interface DiskPressureStats {
+  diskPressureEnabled: boolean;
+  diskObserveOnly: boolean;
+  diskFreeBytes: number | null;
+  diskTotalBytes: number | null;
+  diskUsedBytes: number | null;
+  diskTargetBytes: number | null;
+  diskCriticalBytes: number | null;
+  diskPressureSeverity: 'ok' | 'soft' | 'critical' | null;
+  disks: Array<FsUsage & { targetBytes: number; criticalBytes: number; severity: 'ok' | 'soft' | 'critical' }>;
+}
+
+/**
+ * Best-effort disk-pressure stats for the dashboard gauge and HA sensors.
+ * Reads real free space via statfs on the configured paths; returns null
+ * fields (never throws) when nothing can be read. The reported single-disk
+ * fields reflect the most-pressured filesystem.
+ */
+async function computeDiskPressureStats(): Promise<DiskPressureStats> {
+  const enabled = settingsRepo.getBoolean('diskPressure_enabled', false);
+  const observeOnly = settingsRepo.getBoolean('diskPressure_observeOnly', true);
+  const empty: DiskPressureStats = {
+    diskPressureEnabled: enabled,
+    diskObserveOnly: observeOnly,
+    diskFreeBytes: null,
+    diskTotalBytes: null,
+    diskUsedBytes: null,
+    diskTargetBytes: null,
+    diskCriticalBytes: null,
+    diskPressureSeverity: null,
+    disks: [],
+  };
+
+  let paths: string[] = [];
+  try {
+    const raw = settingsRepo.getValue('diskPressure_paths');
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) paths = parsed.filter((p) => typeof p === 'string' && p.trim().length > 0);
+    }
+  } catch {
+    /* ignore malformed paths */
+  }
+  if (paths.length === 0) return empty;
+
+  const mode = (settingsRepo.getValue('diskPressure_targetMode') as TargetMode) || 'percent';
+  const targetValue = settingsRepo.getNumber('diskPressure_targetValue', 10);
+  const criticalValue = settingsRepo.getNumber('diskPressure_criticalValue', 5);
+
+  const usages = await getUsageForPaths(paths);
+  if (usages.length === 0) return empty;
+
+  const disks = usages.map((fs) => {
+    const targetBytes = resolveTargetBytes(fs, mode, targetValue);
+    const criticalBytes = resolveTargetBytes(fs, mode, criticalValue);
+    const severity: 'ok' | 'soft' | 'critical' =
+      fs.freeBytes < criticalBytes ? 'critical' : fs.freeBytes < targetBytes ? 'soft' : 'ok';
+    return { ...fs, targetBytes, criticalBytes, severity };
+  });
+
+  // Surface the most-pressured filesystem in the flat fields.
+  const rank = { critical: 2, soft: 1, ok: 0 } as const;
+  const worst = disks.reduce((a, b) => (rank[b.severity] > rank[a.severity] ? b : a));
+
+  return {
+    diskPressureEnabled: enabled,
+    diskObserveOnly: observeOnly,
+    diskFreeBytes: worst.freeBytes,
+    diskTotalBytes: worst.totalBytes,
+    diskUsedBytes: worst.usedBytes,
+    diskTargetBytes: worst.targetBytes,
+    diskCriticalBytes: worst.criticalBytes,
+    diskPressureSeverity: worst.severity,
+    disks,
+  };
+}
+
 // GET /api/stats - Get dashboard statistics
-router.get('/', (_req: Request, res: Response) => {
+router.get('/', async (_req: Request, res: Response) => {
   try {
     const db = getDatabase();
 
@@ -93,6 +172,9 @@ router.get('/', (_req: Request, res: Response) => {
       ? Math.round(((thisWeekReclaimed - lastWeekReclaimed) / lastWeekReclaimed) * 100)
       : 0;
 
+    // Disk-pressure / real free-space stats (best-effort; null when unreadable)
+    const diskStats = await computeDiskPressureStats();
+
     res.json({
       success: true,
       data: {
@@ -100,6 +182,9 @@ router.get('/', (_req: Request, res: Response) => {
         totalStorage: mediaStats.totalSize,
         usedStorage: mediaStats.totalSize,
         reclaimableSpace: pendingDeletionSize,
+
+        // Disk-pressure / real free space (additive; for the gauge + HA sensors)
+        ...diskStats,
 
         // Media counts
         movieCount: mediaStats.byType['movie'] ?? 0,

--- a/server/src/routes/webhooks.ts
+++ b/server/src/routes/webhooks.ts
@@ -1,0 +1,104 @@
+import { Router, Request, Response } from 'express';
+import logger from '../utils/logger';
+import { sendWebhook, type WebhookEnvelope } from '../notifications/webhooks';
+import type { NotificationEvent } from '../notifications/templates';
+
+const router = Router();
+
+/**
+ * Build a representative sample payload so the receiver sees a realistic shape.
+ */
+function sampleData(event: NotificationEvent): WebhookEnvelope['data'] {
+  switch (event) {
+    case 'DISK_PRESSURE_TRIGGERED':
+      return {
+        severity: 'soft',
+        path: '/data/media',
+        freeBytes: 850_000_000_000,
+        totalBytes: 12_000_000_000_000,
+        targetBytes: 1_000_000_000_000,
+        deficitBytes: 150_000_000_000,
+        observeOnly: false,
+        itemsQueued: 1,
+        projectedReclaimBytes: 64_000_000_000,
+        deletionAction: 'unmonitor_and_delete',
+        items: [{ id: 1, title: 'Example Movie', type: 'movie', sizeBytes: 64_000_000_000 }],
+        timestamp: new Date().toISOString(),
+      };
+    case 'DELETION_COMPLETE':
+    default:
+      return {
+        itemsDeleted: 3,
+        spaceFreedBytes: 96_000_000_000,
+        spaceFreedGB: '89.4',
+        errors: 0,
+        items: [{ title: 'Example Movie', type: 'movie', ruleName: 'Unwatched > 6mo' }],
+      };
+  }
+}
+
+// POST /api/webhooks/test - Send a sample envelope to a webhook URL (no retry)
+router.post('/test', async (req: Request, res: Response) => {
+  try {
+    const { url, secret } = req.body ?? {};
+    const event: NotificationEvent = (req.body?.event as NotificationEvent) || 'DELETION_COMPLETE';
+
+    if (!url || typeof url !== 'string') {
+      res.status(400).json({ success: false, error: 'A webhook URL is required' });
+      return;
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      res.status(400).json({ success: false, error: 'Invalid URL' });
+      return;
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      res.status(400).json({ success: false, error: 'URL must use http or https' });
+      return;
+    }
+    // Reject credentials embedded in the URL (avoid leaking creds / smuggling).
+    if (parsed.username || parsed.password) {
+      res.status(400).json({ success: false, error: 'URL must not contain credentials' });
+      return;
+    }
+
+    const envelope: WebhookEnvelope = {
+      event,
+      timestamp: new Date().toISOString(),
+      source: 'prunerr',
+      version: 1,
+      data: { ...sampleData(event), test: true },
+    };
+
+    // Single attempt — the user is waiting on the response.
+    const result = await sendWebhook({ url, secret }, envelope, 1);
+
+    if (result.success) {
+      res.json({
+        success: true,
+        message: `Webhook delivered (HTTP ${result.status}).`,
+        data: { status: result.status },
+      });
+    } else {
+      // Redact the upstream error body — only surface the status code so we
+      // don't echo arbitrary internal-endpoint responses back to the client.
+      const safeError = result.status
+        ? `Webhook delivery failed (HTTP ${result.status})`
+        : 'Webhook delivery failed (no response)';
+      res.status(400).json({
+        success: false,
+        error: safeError,
+        data: { status: result.status },
+      });
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Failed to test webhook:', error);
+    res.status(500).json({ success: false, error: `Failed to test webhook: ${message}` });
+  }
+});
+
+export default router;

--- a/server/src/scheduler/index.ts
+++ b/server/src/scheduler/index.ts
@@ -9,6 +9,7 @@ import {
   captureUnraidCapacitySnapshot,
   syncPlexUsers,
   syncPlexLibrary,
+  monitorDiskPressure,
   getTask,
   getAvailableTasks,
   type TaskResult,
@@ -29,12 +30,13 @@ export interface SchedulerConfig {
     captureStorageSnapshot: string;
     captureUnraidCapacitySnapshot: string;
     syncPlexUsers: string;
+    monitorDiskPressure: string;
   };
   timezone: string;
 }
 
 const DEFAULT_CONFIG: SchedulerConfig = {
-  enabledTasks: ['syncPlexLibrary', 'scanLibraries', 'processDeletionQueue', 'sendDeletionReminders', 'captureStorageSnapshot', 'captureUnraidCapacitySnapshot', 'syncPlexUsers'],
+  enabledTasks: ['syncPlexLibrary', 'scanLibraries', 'processDeletionQueue', 'sendDeletionReminders', 'captureStorageSnapshot', 'captureUnraidCapacitySnapshot', 'syncPlexUsers', 'monitorDiskPressure'],
   schedules: {
     syncPlexLibrary: '0 2 * * *', // Daily at 2 AM (before scan, so rules see fresh catalog)
     scanLibraries: '0 3 * * *', // Daily at 3 AM
@@ -43,6 +45,7 @@ const DEFAULT_CONFIG: SchedulerConfig = {
     captureStorageSnapshot: '30 3 * * *', // Daily at 3:30 AM (after scan)
     captureUnraidCapacitySnapshot: '35 3 * * *', // Daily at 3:35 AM (after storage snapshot)
     syncPlexUsers: '45 3 * * *', // Daily at 3:45 AM (after scan)
+    monitorDiskPressure: '*/20 * * * *', // Every 20 minutes (self-disables via settings)
   },
   timezone: 'UTC',
 };
@@ -137,6 +140,11 @@ export class Scheduler {
     // Schedule Plex users sync
     if (this.config.enabledTasks.includes('syncPlexUsers')) {
       this.scheduleJob('syncPlexUsers', this.config.schedules.syncPlexUsers, syncPlexUsers);
+    }
+
+    // Schedule disk-pressure monitor (task self-disables via settings)
+    if (this.config.enabledTasks.includes('monitorDiskPressure')) {
+      this.scheduleJob('monitorDiskPressure', this.config.schedules.monitorDiskPressure, monitorDiskPressure);
     }
 
     this.isRunning = true;

--- a/server/src/scheduler/tasks.ts
+++ b/server/src/scheduler/tasks.ts
@@ -12,6 +12,9 @@ import { logActivity } from '../db/repositories/activity';
 import collectionsRepo from '../db/repositories/collections';
 import { evaluateRuleConditions } from '../rules/engine';
 import { getNotificationService } from '../notifications';
+import { getUsageForPaths, resolveTargetBytes, GiB, type FsUsage, type TargetMode } from '../services/diskSpace';
+import { DeletionAction } from '../rules/types';
+import type { DiskPressureData } from '../notifications/templates';
 import type { EvaluationContext } from '../rules/conditions';
 import type { MediaItem } from '../types';
 
@@ -1216,6 +1219,242 @@ export async function syncPlexLibrary(): Promise<TaskResult> {
 // Task Registry
 // ============================================================================
 
+// ============================================================================
+// Disk-Pressure Reactive Monitor
+// ============================================================================
+
+/** Read the configured media paths for the disk-pressure monitor. */
+export function loadDiskPressurePaths(): string[] {
+  try {
+    const raw = settingsRepo.getValue('diskPressure_paths');
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((p) => typeof p === 'string' && p.trim().length > 0) : [];
+  } catch {
+    return [];
+  }
+}
+
+interface DiskPressureConfig {
+  targetMode: TargetMode;
+  targetValue: number;
+  criticalValue: number;
+  bufferGb: number;
+  observeOnly: boolean;
+  softGraceDays: number;
+  criticalGraceDays: number;
+  criticalAutoProcess: boolean;
+  deletionAction: DeletionAction;
+  maxItemsPerRun: number;
+  maxGbPerRun: number;
+  unwatchedDays: number;
+}
+
+function loadDiskPressureConfig(): DiskPressureConfig {
+  const action = settingsRepo.getValue('diskPressure_deletionAction') as DeletionAction | null;
+  const validAction = action && Object.values(DeletionAction).includes(action)
+    ? action
+    : DeletionAction.UNMONITOR_AND_DELETE;
+  return {
+    targetMode: (settingsRepo.getValue('diskPressure_targetMode') as TargetMode) || 'percent',
+    targetValue: settingsRepo.getNumber('diskPressure_targetValue', 10),
+    criticalValue: settingsRepo.getNumber('diskPressure_criticalValue', 5),
+    bufferGb: settingsRepo.getNumber('diskPressure_bufferGb', 50),
+    observeOnly: settingsRepo.getBoolean('diskPressure_observeOnly', true),
+    softGraceDays: settingsRepo.getNumber('diskPressure_softGraceDays', 7),
+    criticalGraceDays: settingsRepo.getNumber('diskPressure_criticalGraceDays', 0),
+    criticalAutoProcess: settingsRepo.getBoolean('diskPressure_criticalAutoProcess', false),
+    deletionAction: validAction,
+    maxItemsPerRun: settingsRepo.getNumber('diskPressure_maxItemsPerRun', 25),
+    maxGbPerRun: settingsRepo.getNumber('diskPressure_maxGbPerRun', 500),
+    unwatchedDays: settingsRepo.getNumber('diskPressure_unwatchedDays', 90),
+  };
+}
+
+/**
+ * Rank candidate items for reclamation, reusing the recommendations ordering
+ * (oldest-watched first, then largest). Excludes protected / already-pending
+ * items and anything matching the user's exclusion patterns. When a breached
+ * path is given, items on that filesystem are preferred.
+ */
+function selectDiskPressureCandidates(unwatchedDays: number, breachedPath: string): MediaItem[] {
+  const exclusionPatterns = loadExclusionPatterns();
+  const candidates = mediaItemsRepo
+    .getUnwatched(unwatchedDays)
+    .filter((item) => !item.is_protected && item.status !== 'pending_deletion')
+    .filter((item) => !(exclusionPatterns.length > 0 && matchesExclusionPattern(item, exclusionPatterns)));
+
+  return candidates.sort((a, b) => {
+    // Prefer items physically under the breached path (so we free the right FS)
+    const aOnPath = a.file_path?.startsWith(breachedPath) ? 0 : 1;
+    const bOnPath = b.file_path?.startsWith(breachedPath) ? 0 : 1;
+    if (aOnPath !== bOnPath) return aOnPath - bOnPath;
+    // Oldest watched first
+    const aDate = a.last_watched_at ? new Date(a.last_watched_at).getTime() : 0;
+    const bDate = b.last_watched_at ? new Date(b.last_watched_at).getTime() : 0;
+    if (aDate !== bDate) return aDate - bDate;
+    // Then largest first
+    return (b.file_size || 0) - (a.file_size || 0);
+  });
+}
+
+/**
+ * Reactive disk-pressure monitor. Runs frequently; when free space on a
+ * configured filesystem drops below the soft/critical threshold, it reclaims
+ * just enough lowest-value content to recover (or, in observe-only mode, only
+ * reports what it would do). Self-disables when `diskPressure_enabled` is off.
+ */
+export async function monitorDiskPressure(): Promise<TaskResult> {
+  const startedAt = new Date();
+  const taskName = 'monitorDiskPressure';
+  const done = (message: string, data?: Record<string, unknown>, success = true): TaskResult => {
+    const completedAt = new Date();
+    return { success, taskName, startedAt, completedAt, durationMs: completedAt.getTime() - startedAt.getTime(), message, data };
+  };
+
+  if (!settingsRepo.getBoolean('diskPressure_enabled', false)) {
+    return done('Disk-pressure monitoring disabled');
+  }
+
+  // Don't fight the nightly scan/sync over the same items.
+  if (isSyncInProgress() || rulesRepo.scanHistory.getRunning()) {
+    return done('Scan or sync in progress, skipping disk-pressure check');
+  }
+
+  const paths = loadDiskPressurePaths();
+  if (paths.length === 0) {
+    return done('No media paths configured for disk-pressure monitoring');
+  }
+
+  const cfg = loadDiskPressureConfig();
+  const usages = await getUsageForPaths(paths);
+  if (usages.length === 0) {
+    return done('Could not read any configured paths', undefined, true);
+  }
+
+  // Find the most-breached filesystem (largest deficit vs its soft target).
+  type Breach = { fs: FsUsage; severity: 'soft' | 'critical'; softTarget: number; criticalTarget: number; deficit: number };
+  let worst: Breach | null = null;
+  for (const fs of usages) {
+    const softTarget = resolveTargetBytes(fs, cfg.targetMode, cfg.targetValue);
+    const criticalTarget = resolveTargetBytes(fs, cfg.targetMode, cfg.criticalValue);
+    const severity = fs.freeBytes < criticalTarget ? 'critical' : fs.freeBytes < softTarget ? 'soft' : null;
+    if (!severity) continue;
+    const deficit = softTarget - fs.freeBytes;
+    if (!worst || deficit > worst.deficit) {
+      worst = { fs, severity, softTarget, criticalTarget, deficit };
+    }
+  }
+
+  if (!worst) {
+    return done('All filesystems above target', { checked: usages.length });
+  }
+
+  const { fs, severity, softTarget, deficit } = worst;
+  const targetBytes = severity === 'critical' ? worst.criticalTarget : softTarget;
+  const deletesFiles = cfg.deletionAction !== DeletionAction.UNMONITOR_ONLY;
+  // Reclaim enough to clear the soft target plus a buffer so we don't re-trigger.
+  const reclaimGoal = deficit + cfg.bufferGb * GiB;
+  const maxBytes = cfg.maxGbPerRun * GiB;
+
+  // Pick items until we've projected enough reclaim or hit a safety cap.
+  const ranked = selectDiskPressureCandidates(cfg.unwatchedDays, fs.path);
+  const chosen: MediaItem[] = [];
+  let projected = 0;
+  for (const item of ranked) {
+    if (chosen.length >= cfg.maxItemsPerRun) break;
+    if (deletesFiles && projected >= reclaimGoal) break;
+    if (deletesFiles && projected + (item.file_size || 0) > maxBytes && chosen.length > 0) break;
+    chosen.push(item);
+    if (deletesFiles) projected += item.file_size || 0;
+  }
+
+  const graceDays = severity === 'critical' ? cfg.criticalGraceDays : cfg.softGraceDays;
+
+  // Queue (unless observe-only). Suppress per-item notifications so we emit a
+  // single DISK_PRESSURE_TRIGGERED event below instead of ITEMS_MARKED noise.
+  let itemsQueued = 0;
+  if (!cfg.observeOnly && chosen.length > 0) {
+    const deletionService = getDeletionService();
+    for (const item of chosen) {
+      try {
+        await deletionService.markForDeletion(item.id, {
+          gracePeriodDays: graceDays,
+          deletionAction: cfg.deletionAction,
+          skipNotification: true,
+        });
+        itemsQueued++;
+      } catch (error) {
+        logger.warn(`Disk-pressure: failed to queue item ${item.id}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    // Critical + auto-process: reclaim immediately rather than waiting for grace.
+    if (severity === 'critical' && cfg.criticalAutoProcess && itemsQueued > 0) {
+      try {
+        await deletionService.processPendingDeletions(false);
+      } catch (error) {
+        logger.error('Disk-pressure: critical auto-process failed:', error);
+      }
+    }
+  }
+
+  // Emit the event (Discord + webhooks). Use DI notifier when wired.
+  const notifier = dependencies.notificationService ?? {
+    notify: (event: string, data: Record<string, unknown>) =>
+      getNotificationService().notify(event as any, data).then(() => undefined),
+  };
+  const eventData: DiskPressureData = {
+    severity,
+    path: fs.path,
+    freeBytes: fs.freeBytes,
+    totalBytes: fs.totalBytes,
+    targetBytes,
+    deficitBytes: Math.max(0, deficit),
+    observeOnly: cfg.observeOnly,
+    itemsQueued,
+    projectedReclaimBytes: projected,
+    deletionAction: cfg.deletionAction,
+    items: chosen.map((i) => ({ id: i.id, title: i.title, type: i.type, sizeBytes: i.file_size || 0 })),
+    timestamp: startedAt.toISOString(),
+  };
+  try {
+    await notifier.notify('DISK_PRESSURE_TRIGGERED', eventData as unknown as Record<string, unknown>);
+  } catch (error) {
+    logger.error('Disk-pressure: failed to send notification:', error);
+  }
+
+  // Activity log
+  try {
+    logActivity({
+      eventType: 'disk_pressure',
+      action: cfg.observeOnly
+        ? `Disk pressure (${severity}) on ${fs.path} — ${chosen.length} item(s) would be reclaimed (observe-only)`
+        : `Disk pressure (${severity}) on ${fs.path} — queued ${itemsQueued} item(s)`,
+      actorType: 'scheduler',
+      actorName: 'Disk-pressure monitor',
+      metadata: JSON.stringify({
+        severity,
+        path: fs.path,
+        freeBytes: fs.freeBytes,
+        targetBytes,
+        itemsQueued,
+        observeOnly: cfg.observeOnly,
+        projectedReclaimBytes: projected,
+      }),
+    });
+  } catch (error) {
+    logger.warn('Disk-pressure: failed to log activity:', error);
+  }
+
+  return done(
+    cfg.observeOnly
+      ? `Observe-only: ${chosen.length} item(s) flagged for ${severity} pressure on ${fs.path}`
+      : `Queued ${itemsQueued} item(s) for ${severity} pressure on ${fs.path}`,
+    { severity, path: fs.path, itemsQueued, projectedReclaimBytes: projected, observeOnly: cfg.observeOnly }
+  );
+}
+
 export type TaskFunction = () => Promise<TaskResult>;
 
 export const taskRegistry: Record<string, TaskFunction> = {
@@ -1226,6 +1465,7 @@ export const taskRegistry: Record<string, TaskFunction> = {
   captureStorageSnapshot,
   captureUnraidCapacitySnapshot,
   syncPlexUsers,
+  monitorDiskPressure,
 };
 
 /**

--- a/server/src/services/__tests__/diskSpace.test.ts
+++ b/server/src/services/__tests__/diskSpace.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const statfsMock = vi.fn();
+
+vi.mock('fs/promises', () => ({
+  statfs: (...args: unknown[]) => statfsMock(...args),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { getFsUsage, getUsageForPaths, resolveTargetBytes, GiB } from '../diskSpace';
+
+// bsize 4096, blocks 1,000,000 => 4.096 GB total; bavail 250,000 => ~1.024 GB free
+const sample = { bsize: 4096, blocks: 1_000_000, bfree: 300_000, bavail: 250_000 };
+
+describe('getFsUsage', () => {
+  beforeEach(() => statfsMock.mockReset());
+
+  it('computes total/free/used from statfs using bavail for free', async () => {
+    statfsMock.mockResolvedValue(sample);
+    const usage = await getFsUsage('/data');
+    expect(usage).not.toBeNull();
+    expect(usage!.totalBytes).toBe(4096 * 1_000_000);
+    expect(usage!.freeBytes).toBe(4096 * 250_000); // bavail, not bfree
+    expect(usage!.usedBytes).toBe(4096 * 1_000_000 - 4096 * 300_000);
+    expect(usage!.key).toBe('1000000:4096');
+  });
+
+  it('returns null (never throws) when statfs rejects', async () => {
+    statfsMock.mockImplementationOnce(async () => {
+      throw new Error('ENOENT');
+    });
+    expect(await getFsUsage('/missing')).toBeNull();
+  });
+
+  it('returns null when total is non-positive', async () => {
+    statfsMock.mockResolvedValue({ bsize: 4096, blocks: 0, bfree: 0, bavail: 0 });
+    expect(await getFsUsage('/empty')).toBeNull();
+  });
+});
+
+describe('getUsageForPaths', () => {
+  beforeEach(() => statfsMock.mockReset());
+
+  it('dedupes paths on the same filesystem and drops unreadable ones', async () => {
+    statfsMock
+      .mockResolvedValueOnce(sample) // /data/movies
+      .mockResolvedValueOnce(sample) // /data/tv  -> same key, deduped
+      .mockImplementationOnce(async () => {
+        throw new Error('nope');
+      }); // /other -> dropped
+    const usages = await getUsageForPaths(['/data/movies', '/data/tv', '/other']);
+    expect(usages).toHaveLength(1);
+    expect(usages[0]!.path).toBe('/data/movies');
+  });
+});
+
+describe('resolveTargetBytes', () => {
+  const fs = { path: '/data', totalBytes: 100 * GiB, freeBytes: 10 * GiB, usedBytes: 90 * GiB, key: 'k' };
+
+  it('percent mode = that % of total', () => {
+    expect(resolveTargetBytes(fs, 'percent', 10)).toBe(10 * GiB);
+  });
+
+  it('percent mode clamps to 0..100', () => {
+    expect(resolveTargetBytes(fs, 'percent', 250)).toBe(100 * GiB);
+    expect(resolveTargetBytes(fs, 'percent', -5)).toBe(0);
+  });
+
+  it('absolute mode = value in GB', () => {
+    expect(resolveTargetBytes(fs, 'absolute', 1)).toBe(GiB);
+  });
+});

--- a/server/src/services/diskSpace.ts
+++ b/server/src/services/diskSpace.ts
@@ -1,0 +1,94 @@
+import { statfs } from 'fs/promises';
+import logger from '../utils/logger';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface FsUsage {
+  /** The path that was probed */
+  path: string;
+  totalBytes: number;
+  freeBytes: number;
+  usedBytes: number;
+  /** Coarse filesystem identity used to dedupe multiple paths on one mount */
+  key: string;
+}
+
+export type TargetMode = 'percent' | 'absolute';
+
+// ============================================================================
+// Reading free space
+// ============================================================================
+
+/**
+ * Read filesystem usage for a single path via statfs. Returns null (never
+ * throws) when the path can't be read — a bad path or an OS where statfs
+ * misbehaves must not take down the disk-pressure monitor.
+ *
+ * Uses `bavail` (blocks available to unprivileged users), not `bfree`, so the
+ * number matches what the app can actually write.
+ */
+export async function getFsUsage(path: string): Promise<FsUsage | null> {
+  try {
+    const stats = await statfs(path);
+    const blockSize = stats.bsize;
+    const totalBytes = blockSize * stats.blocks;
+    const freeBytes = blockSize * stats.bavail;
+    const usedBytes = Math.max(0, totalBytes - blockSize * stats.bfree);
+
+    if (!Number.isFinite(totalBytes) || totalBytes <= 0) {
+      logger.warn(`statfs returned non-positive total for ${path}`);
+      return null;
+    }
+
+    return {
+      path,
+      totalBytes,
+      freeBytes,
+      usedBytes,
+      key: `${stats.blocks}:${stats.bsize}`,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`Failed to read disk usage for ${path}: ${message}`);
+    return null;
+  }
+}
+
+/**
+ * Read usage for several paths, dropping unreadable ones and de-duplicating
+ * paths that resolve to the same filesystem (the common single-mount case).
+ * The first path wins for a given filesystem.
+ */
+export async function getUsageForPaths(paths: string[]): Promise<FsUsage[]> {
+  const results = await Promise.all(paths.map((p) => getFsUsage(p)));
+  const seen = new Set<string>();
+  const deduped: FsUsage[] = [];
+  for (const usage of results) {
+    if (!usage) continue;
+    if (seen.has(usage.key)) continue;
+    seen.add(usage.key);
+    deduped.push(usage);
+  }
+  return deduped;
+}
+
+// ============================================================================
+// Targets
+// ============================================================================
+
+/**
+ * Resolve a configured target to an absolute byte threshold for a given
+ * filesystem. Percent is interpreted as "keep this % of total free".
+ */
+export function resolveTargetBytes(fs: FsUsage, mode: TargetMode, value: number): number {
+  if (mode === 'percent') {
+    const pct = Math.max(0, Math.min(100, value));
+    return Math.round((pct / 100) * fs.totalBytes);
+  }
+  // absolute: value is in GB
+  return Math.round(value * 1024 * 1024 * 1024);
+}
+
+export const GiB = 1024 * 1024 * 1024;

--- a/server/src/services/init.ts
+++ b/server/src/services/init.ts
@@ -405,10 +405,36 @@ function initializeSchedulerFromSettings(): void {
       }
       logger.info(`Plex sync schedule initialized from settings: ${effInterval} at ${effTime} (cron: ${psCron})`);
     }
+
+    // Hydrate the disk-pressure monitor schedule/enabled state from settings.
+    applyDiskPressureSchedule();
   } catch (error) {
     logger.error('Failed to initialize scheduler from settings:', error);
     // Fall back to default schedule - don't fail startup
   }
+}
+
+/**
+ * Apply the disk-pressure monitor's enabled state and interval from settings.
+ * Called at startup and whenever disk-pressure settings are saved, so the
+ * schedule survives restarts and reacts to config changes without a restart.
+ */
+export function applyDiskPressureSchedule(): void {
+  const scheduler = getScheduler();
+  const enabled = settingsRepo.getBoolean('diskPressure_enabled', false);
+
+  if (!enabled) {
+    scheduler.disableTask('monitorDiskPressure');
+    logger.info('Disk-pressure monitor disabled (per settings)');
+    return;
+  }
+
+  // Clamp the interval to a sane minute-step cron (1–59 minutes).
+  const intervalMinutes = Math.min(59, Math.max(1, settingsRepo.getNumber('diskPressure_intervalMinutes', 20)));
+  const cronExpression = `*/${intervalMinutes} * * * *`;
+  scheduler.updateSchedule('monitorDiskPressure', cronExpression);
+  scheduler.enableTask('monitorDiskPressure');
+  logger.info(`Disk-pressure monitor scheduled every ${intervalMinutes} min (cron: ${cronExpression})`);
 }
 
 /**


### PR DESCRIPTION
@
## Summary

Two complementary features, plus SSRF hardening:

### ⚡ Disk-Pressure Reactive Mode
Maintain free-space *headroom* instead of relying only on the nightly cron. A new `monitorDiskPressure` task (every ~20 min, self-disables via settings) reads **real free space via `fs.statfs`** on configured paths and reclaims the lowest-value content only when free space drops below a soft/critical target — then stops.

- Reuses the recommendations ranking + deletion service; honors protections and exclusion patterns
- Per-run item/GB safety caps
- **Safe by default:** observe-only ON (logs what it *would* reclaim, deletes nothing); critical auto-delete OFF until opted in
- Dashboard free-space gauge (`DiskPressureWidget`) + a Disk Pressure settings panel
- Additive disk fields on `GET /api/stats` (`diskFreeBytes`, `diskTargetBytes`, `diskPressureSeverity`, …), null when unreadable

### 🏠 Outbound Webhooks + Home Assistant
Generalizes the Discord-only notifier into a generic webhook fan-out with a versioned JSON envelope and optional HMAC signing (`X-Prunerr-Signature`). Discord and webhooks are now gated **independently**. New `DISK_PRESSURE_TRIGGERED` event flows to both.

- Webhooks settings panel (URL, per-event opt-in, secret, test button) + `POST /api/webhooks/test`
- `docs/home-assistant.md`: HA consumes events, pulls `/api/stats`, and triggers scans via `/api/scan/trigger`

### 🔒 SSRF hardening
- `redirect: manual` so a target cant 302-bounce the server into an internal endpoint
- Reject embedded credentials in the test URL; redact upstream error text
- A private-IP denylist is **intentionally not applied** — LAN hosts (Home Assistant, n8n) are the intended targets

## Notes
- No DB migration — flat `diskPressure_*` settings keys + a `webhooks_targets` JSON blob
- `fs.statfs` verified working on Windows

## Testing
- Server typecheck clean; **74 tests pass** (12 new across `diskSpace` + `webhooks` — byte math, dedupe, envelope/HMAC, retry-on-5xx / no-retry-on-4xx, event fan-out filtering)
- Client typecheck + production build clean
- **Live end-to-end:** delivered a real webhook to a local listener (verified envelope, `X-Prunerr-Event` header, matching HMAC signature); settings round-tripped; `/api/stats` returned real free/total bytes via `statfs`