### PR TITLE
Fix duplicate movies lingering after Radarr upgrades (#49)

### DIFF
--- a/server/src/db/repositories/__tests__/deleteStale.test.ts
+++ b/server/src/db/repositories/__tests__/deleteStale.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import fs from 'fs';
+
+// Real on-disk SQLite (better-sqlite3 needs a file for WAL). Point config at a
+// temp DB before the db module reads it, and silence the logger. Computed via
+// vi.hoisted so it's available inside the hoisted vi.mock factory below.
+const { tmpDbPath } = vi.hoisted(() => {
+  const osMod = require('os');
+  const pathMod = require('path');
+  return {
+    tmpDbPath: pathMod.join(osMod.tmpdir(), `prunerr-stale-test-${process.pid}-${Date.now()}.db`),
+  };
+});
+
+vi.mock('../../../config', () => ({
+  default: { dbPath: tmpDbPath, nodeEnv: 'test' },
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { initializeDatabase, getDatabase, closeDatabase } from '../../index';
+import { createMediaItem, deleteStaleByLibraryKey, getAllMediaItems } from '../mediaItems';
+
+describe('deleteStaleByLibraryKey', () => {
+  beforeAll(() => {
+    initializeDatabase();
+  });
+
+  afterAll(() => {
+    closeDatabase();
+    for (const suffix of ['', '-wal', '-shm']) {
+      try { fs.unlinkSync(tmpDbPath + suffix); } catch { /* ignore */ }
+    }
+  });
+
+  beforeEach(() => {
+    getDatabase().prepare('DELETE FROM media_items').run();
+  });
+
+  it('removes only rows whose plex_id is missing from the current Plex listing', () => {
+    // Two distinct movies plus a stale duplicate of the first — the kind of
+    // leftover a Radarr upgrade produces when Plex assigns a new ratingKey.
+    createMediaItem({ type: 'movie', title: 'Alien', plex_id: 'rk-alien-new', library_key: '1' });
+    createMediaItem({ type: 'movie', title: 'Alien', plex_id: 'rk-alien-old', library_key: '1' });
+    createMediaItem({ type: 'movie', title: 'Aliens', plex_id: 'rk-aliens', library_key: '1' });
+
+    const removed = deleteStaleByLibraryKey('1', ['rk-alien-new', 'rk-aliens']);
+    expect(removed).toBe(1);
+
+    const remaining = getAllMediaItems({ limit: 100 }).data.map((i) => i.plex_id).sort();
+    expect(remaining).toEqual(['rk-alien-new', 'rk-aliens']);
+  });
+
+  it('never touches rows from another library', () => {
+    createMediaItem({ type: 'movie', title: 'A', plex_id: 'lib1-a', library_key: '1' });
+    createMediaItem({ type: 'show', title: 'B', plex_id: 'lib2-b', library_key: '2' });
+
+    // Scanning library 1 with an empty seen set must not delete library 2's row.
+    const removed = deleteStaleByLibraryKey('1', []);
+    expect(removed).toBe(1);
+
+    const remaining = getAllMediaItems({ limit: 100 }).data.map((i) => i.plex_id);
+    expect(remaining).toEqual(['lib2-b']);
+  });
+
+  it('preserves soft-deleted tombstones so re-add detection keeps working', () => {
+    const tombstone = createMediaItem({ type: 'movie', title: 'Gone', plex_id: 'rk-gone', library_key: '1' });
+    getDatabase()
+      .prepare("UPDATE media_items SET status = 'deleted', deleted_at = ? WHERE id = ?")
+      .run(new Date().toISOString(), tombstone.id);
+
+    // 'rk-gone' is absent from the listing but must survive as a tombstone.
+    const removed = deleteStaleByLibraryKey('1', []);
+    expect(removed).toBe(0);
+  });
+});

--- a/server/src/db/repositories/mediaItems.ts
+++ b/server/src/db/repositories/mediaItems.ts
@@ -520,6 +520,41 @@ export function deleteByPlexIds(plexIds: string[]): number {
   return totalChanges;
 }
 
+/**
+ * Remove rows for a library whose Plex item no longer exists.
+ *
+ * After a successful scan of a library, `seenPlexIds` holds every ratingKey
+ * Plex currently reports for it. Any non-tombstone row tagged with this
+ * library_key whose plex_id is missing from that set is stale — typically a
+ * Radarr upgrade where Plex assigned the rebuilt movie a fresh ratingKey,
+ * leaving the old row behind as a duplicate. Soft-deleted tombstones
+ * (status='deleted') are preserved so re-add detection keeps working.
+ */
+export function deleteStaleByLibraryKey(libraryKey: string, seenPlexIds: string[]): number {
+  const db = getDatabase();
+  const seen = new Set(seenPlexIds);
+
+  const rows = db
+    .prepare<[string], { id: number; plex_id: string | null }>(
+      "SELECT id, plex_id FROM media_items WHERE library_key = ? AND status != 'deleted' AND plex_id IS NOT NULL"
+    )
+    .all(libraryKey);
+
+  const staleIds = rows.filter((r) => r.plex_id && !seen.has(r.plex_id)).map((r) => r.id);
+  if (staleIds.length === 0) return 0;
+
+  let removed = 0;
+  const CHUNK = 500;
+  for (let i = 0; i < staleIds.length; i += CHUNK) {
+    const chunk = staleIds.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => '?').join(',');
+    removed += db.prepare(`DELETE FROM media_items WHERE id IN (${placeholders})`).run(...chunk).changes;
+  }
+
+  logger.info(`Pruned ${removed} stale media items from library ${libraryKey} (no longer in Plex)`);
+  return removed;
+}
+
 export function deleteByTitles(titles: string[]): number {
   if (titles.length === 0) return 0;
   const db = getDatabase();
@@ -671,6 +706,7 @@ export default {
   delete: deleteMediaItem,
   deleteByLibraryKey,
   deleteByPlexIds,
+  deleteStaleByLibraryKey,
   deleteByTitles,
   updateStatus: updateMediaItemStatus,
   protect: protectMediaItem,

--- a/server/src/services/scanner.ts
+++ b/server/src/services/scanner.ts
@@ -61,6 +61,10 @@ export class ScannerService {
   // Database callback - to be injected
   private dbCallback: ((items: SyncedMediaData[]) => Promise<void>) | null = null;
 
+  // Prune callback - to be injected. Removes DB rows for a library whose Plex
+  // item no longer exists (e.g. Radarr upgrades that get a new ratingKey).
+  private pruneCallback: ((libraryKey: string, seenPlexIds: string[]) => Promise<number>) | null = null;
+
   // Set once per scan after the first failed Overseerr lookup, so a systemic
   // failure (bad URL/key) is logged once instead of per item.
   private overseerrErrorLogged = false;
@@ -174,6 +178,14 @@ export class ScannerService {
   }
 
   /**
+   * Set the callback for pruning stale items (present in the DB but no longer
+   * in Plex) after a library is successfully scanned.
+   */
+  setPruneCallback(callback: (libraryKey: string, seenPlexIds: string[]) => Promise<number>): void {
+    this.pruneCallback = callback;
+  }
+
+  /**
    * Test all configured service connections
    */
   async testConnections(): Promise<Record<string, boolean>> {
@@ -211,6 +223,7 @@ export class ScannerService {
     let itemsScanned = 0;
     let itemsAdded = 0;
     let itemsUpdated = 0;
+    let itemsRemoved = 0;
     let itemsFlagged = 0;
 
     logger.info('Starting full library scan');
@@ -276,6 +289,7 @@ export class ScannerService {
           itemsScanned += result.itemsScanned;
           itemsAdded += result.itemsAdded;
           itemsUpdated += result.itemsUpdated;
+          itemsRemoved += result.itemsRemoved;
           itemsFlagged += result.itemsFlagged;
           errors.push(...result.errors);
 
@@ -302,6 +316,7 @@ export class ScannerService {
         itemsScanned,
         itemsAdded,
         itemsUpdated,
+        itemsRemoved,
         itemsFlagged,
         errors: errors.length,
       });
@@ -362,6 +377,7 @@ export class ScannerService {
       itemsScanned,
       itemsAdded,
       itemsUpdated,
+      itemsRemoved,
       itemsFlagged,
       errors,
     };
@@ -377,6 +393,7 @@ export class ScannerService {
     itemsScanned: number;
     itemsAdded: number;
     itemsUpdated: number;
+    itemsRemoved: number;
     itemsFlagged: number;
     errors: ScanError[];
   }> {
@@ -384,6 +401,7 @@ export class ScannerService {
     let itemsScanned = 0;
     let itemsAdded = 0;
     let itemsUpdated = 0;
+    let itemsRemoved = 0;
     let itemsFlagged = 0;
 
     logger.info(`Scanning library: ${library.title} (${library.type})`);
@@ -425,13 +443,34 @@ export class ScannerService {
     }
 
     // Persist to database if callback is set
+    let persistSucceeded = false;
     if (this.dbCallback && syncedItems.length > 0) {
       try {
         await this.dbCallback(syncedItems);
         itemsAdded = syncedItems.length; // Simplified - actual implementation would track adds vs updates
+        persistSucceeded = true;
       } catch (error) {
         errors.push({
           message: `Failed to persist items: ${(error as Error).message}`,
+          service: 'database',
+          stack: (error as Error).stack,
+        });
+      }
+    }
+
+    // Prune stale rows: DB items tagged with this library whose Plex item no
+    // longer exists (e.g. a Radarr upgrade that landed on a new ratingKey, or
+    // content removed from Plex). The seen set is built from the raw Plex
+    // listing so items that merely failed per-item processing are never pruned.
+    // Only run when the library returned items and persistence succeeded, so a
+    // transient Plex/DB hiccup can't wipe the library.
+    if (this.pruneCallback && persistSucceeded && items.length > 0) {
+      try {
+        const seenPlexIds = items.map((item) => item.ratingKey).filter((k): k is string => Boolean(k));
+        itemsRemoved = await this.pruneCallback(library.key, seenPlexIds);
+      } catch (error) {
+        errors.push({
+          message: `Failed to prune stale items: ${(error as Error).message}`,
           service: 'database',
           stack: (error as Error).stack,
         });
@@ -453,10 +492,11 @@ export class ScannerService {
 
     logger.info(`Completed scanning library: ${library.title}`, {
       itemsScanned,
+      itemsRemoved,
       errors: errors.length,
     });
 
-    return { itemsScanned, itemsAdded, itemsUpdated, itemsFlagged, errors };
+    return { itemsScanned, itemsAdded, itemsUpdated, itemsRemoved, itemsFlagged, errors };
   }
 
   /**

--- a/server/src/services/syncCoordinator.ts
+++ b/server/src/services/syncCoordinator.ts
@@ -59,6 +59,9 @@ function getScanner(): ScannerService {
         }
       }
     });
+    scannerService.setPruneCallback(async (libraryKey, seenPlexIds) => {
+      return mediaItemsRepo.deleteStaleByLibraryKey(libraryKey, seenPlexIds);
+    });
   }
   return scannerService;
 }

--- a/server/src/services/types.ts
+++ b/server/src/services/types.ts
@@ -617,6 +617,7 @@ export interface ScanResult {
   itemsScanned: number;
   itemsAdded: number;
   itemsUpdated: number;
+  itemsRemoved: number;
   itemsFlagged: number;
   errors: ScanError[];
 }


### PR DESCRIPTION
Fixes #49.

## Problem

The Media Library showed the same movie multiple times — duplicate cards for movies that had been **upgraded by Radarr**. Emptying Plex's trash and re-syncing didn't clear them.

## Root cause

Library sync only ever **upserts** items, keyed by Plex's `ratingKey` (stored as `plex_id`), and never removed DB rows whose Plex item had disappeared. When Radarr upgrades a movie, Plex frequently assigns the rebuilt movie a **new `ratingKey`**, so Prunerr inserted a fresh row while the old one lingered forever as a duplicate. Because Prunerr had no mechanism to prune rows that are gone from Plex, emptying the Plex trash + re-syncing couldn't help.

The only orphan-cleanup that existed ran solely when a user changed *library exclusions* — never on a normal sync.

## Fix

After each library is scanned **successfully**, prune non-tombstone rows tagged with that library whose `plex_id` is absent from Plex's current listing (`deleteStaleByLibraryKey`), wired into the scanner via a new `setPruneCallback`.

Safety guards:
- The "seen" set is built from Plex's raw listing, so items that merely failed per-item processing are never pruned.
- Pruning is skipped when the library returned **no items** or persistence failed, so a transient Plex/DB hiccup can't wipe a library.
- **Soft-deleted tombstones** (`status='deleted'`) are explicitly excluded, so Prunerr's own deletions and re-add detection are untouched.

## Tests

- `npm run typecheck` clean.
- Full suite green: 88 tests (85 existing + 3 new) covering the prune, cross-library isolation, and tombstone preservation.