### PR TITLE
Add per-library rule targeting (discussion #51)

### DIFF
--- a/client/src/components/Rules/LivePreview.tsx
+++ b/client/src/components/Rules/LivePreview.tsx
@@ -23,6 +23,8 @@ export interface LivePreviewSummary {
 interface LivePreviewProps {
   root: ConditionNode;
   mediaType?: 'all' | 'movie' | 'show' | 'tv';
+  /** Restrict the preview to these Plex library keys. Empty = all libraries. */
+  libraryKeys?: string[];
   /** If false, shows an inert placeholder. */
   enabled?: boolean;
   /**
@@ -49,10 +51,11 @@ interface PreviewData {
  * Live preview panel for the v2 rule builder. Calls POST /api/rules/preview
  * with the current condition tree (debounced) and renders stats + samples.
  */
-export function LivePreview({ root, mediaType = 'all', enabled = true, onSummaryChange }: LivePreviewProps) {
+export function LivePreview({ root, mediaType = 'all', libraryKeys, enabled = true, onSummaryChange }: LivePreviewProps) {
   const { t } = useTranslation('rules');
   const [debouncedRoot, setDebouncedRoot] = useState<ConditionNode>(root);
   const [debouncedMediaType, setDebouncedMediaType] = useState(mediaType);
+  const [debouncedLibraryKeys, setDebouncedLibraryKeys] = useState(libraryKeys);
   const [preview, setPreview] = useState<PreviewData | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [isPending, setIsPending] = useState(false);
@@ -65,9 +68,10 @@ export function LivePreview({ root, mediaType = 'all', enabled = true, onSummary
     const handle = setTimeout(() => {
       setDebouncedRoot(root);
       setDebouncedMediaType(mediaType);
+      setDebouncedLibraryKeys(libraryKeys);
     }, DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [root, mediaType]);
+  }, [root, mediaType, libraryKeys]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -80,6 +84,9 @@ export function LivePreview({ root, mediaType = 'all', enabled = true, onSummary
         version: 2,
         root: stripUiIds(debouncedRoot),
         mediaType: debouncedMediaType,
+        ...(debouncedLibraryKeys && debouncedLibraryKeys.length > 0
+          ? { libraryKeys: debouncedLibraryKeys }
+          : {}),
       })
       .then((data) => {
         if (myGen !== generation.current) return; // stale
@@ -91,7 +98,7 @@ export function LivePreview({ root, mediaType = 'all', enabled = true, onSummary
         setError(err);
         setIsPending(false);
       });
-  }, [debouncedRoot, debouncedMediaType, enabled]);
+  }, [debouncedRoot, debouncedMediaType, debouncedLibraryKeys, enabled]);
 
   // Surface a compact summary to any consumer (mobile chip etc.). We fire on
   // every state change so the chip stays in sync with whatever the panel

--- a/client/src/components/Rules/MobilePreviewSheet.tsx
+++ b/client/src/components/Rules/MobilePreviewSheet.tsx
@@ -15,6 +15,8 @@ import type { ConditionNode } from '@/types';
 interface MobilePreviewSheetProps {
   root: ConditionNode;
   mediaType?: 'all' | 'movie' | 'show' | 'tv';
+  /** Restrict the preview to these Plex library keys. Empty = all libraries. */
+  libraryKeys?: string[];
   /** If false, the chip is hidden entirely (e.g. on the Templates tab). */
   enabled?: boolean;
 }
@@ -29,6 +31,7 @@ interface MobilePreviewSheetProps {
 export function MobilePreviewSheet({
   root,
   mediaType = 'all',
+  libraryKeys,
   enabled = true,
 }: MobilePreviewSheetProps) {
   const { t } = useTranslation('rules');
@@ -211,6 +214,7 @@ export function MobilePreviewSheet({
           <LivePreview
             root={root}
             mediaType={mediaType}
+            libraryKeys={libraryKeys}
             enabled={enabled}
             onSummaryChange={setSummary}
           />

--- a/client/src/components/Rules/Rules.tsx
+++ b/client/src/components/Rules/Rules.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
 import {
   Plus,
   Edit2,
@@ -20,6 +21,7 @@ import { Button } from '@/components/common/Button';
 import { Badge } from '@/components/common/Badge';
 import { useToast } from '@/components/common/Toast';
 import { useRules, useCreateRule, useUpdateRule, useDeleteRule, useToggleRule, useRunRule } from '@/hooks/useApi';
+import { libraryApi } from '@/services/api';
 import { SmartRuleBuilder } from './SmartRuleBuilder';
 import { ErrorState } from '@/components/common/ErrorState';
 import { EmptyState } from '@/components/common/EmptyState';
@@ -44,6 +46,16 @@ export default function Rules() {
   const { t } = useTranslation('rules');
 
   const { data: rules, isLoading, isError, error, refetch } = useRules();
+
+  // Library titles for the per-rule library badges. Fails quietly when Plex
+  // isn't configured — badges fall back to showing the raw keys.
+  const { data: plexLibraries } = useQuery({
+    queryKey: ['plexLibraries'],
+    queryFn: libraryApi.getPlexLibraries,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+  const libraryTitleByKey = new Map((plexLibraries ?? []).map((lib) => [lib.key, lib.title]));
   const createMutation = useCreateRule();
   const updateMutation = useUpdateRule();
   const deleteMutation = useDeleteRule();
@@ -165,6 +177,7 @@ export default function Rules() {
             <RuleCard
               key={rule.id}
               rule={rule}
+              libraryTitleByKey={libraryTitleByKey}
               expanded={expandedRule === rule.id}
               isRunning={runningRuleId === rule.id}
               onToggleExpand={() =>
@@ -202,6 +215,8 @@ export default function Rules() {
 
 interface RuleCardProps {
   rule: Rule;
+  /** Plex library key → display title, for the library targeting badges. */
+  libraryTitleByKey: Map<string, string>;
   expanded: boolean;
   isRunning: boolean;
   onToggleExpand: () => void;
@@ -213,6 +228,7 @@ interface RuleCardProps {
 
 function RuleCard({
   rule,
+  libraryTitleByKey,
   expanded,
   isRunning,
   onToggleExpand,
@@ -275,6 +291,12 @@ function RuleCard({
                 >
                   {!rule.mediaType || rule.mediaType === 'all' ? t('card.allMedia', 'All Media') : rule.mediaType}
                 </Badge>
+                {rule.libraryKeys && rule.libraryKeys.length > 0 &&
+                  rule.libraryKeys.map((key) => (
+                    <Badge key={key} variant="accent" className="ml-1">
+                      {libraryTitleByKey.get(key) ?? t('card.libraryKey', 'Library {{key}}', { key })}
+                    </Badge>
+                  ))}
               </p>
             </div>
           </div>

--- a/client/src/components/Rules/SmartRuleBuilder.tsx
+++ b/client/src/components/Rules/SmartRuleBuilder.tsx
@@ -101,6 +101,23 @@ interface ActiveSentenceCondition {
   value: number | string;
 }
 
+/**
+ * Only included movie/show libraries are valid rule targets: excluded
+ * libraries are never scanned (their items are purged), so offering them
+ * would create rules that silently match nothing. When the rule is movie-
+ * or show-only, further narrow to matching library types.
+ */
+function isSelectableLibrary(
+  lib: { key: string; title: string; type: string; excluded: boolean },
+  mediaType: 'all' | 'movie' | 'show'
+): boolean {
+  if (lib.excluded) return false;
+  if (lib.type !== 'movie' && lib.type !== 'show') return false;
+  if (mediaType === 'movie') return lib.type === 'movie';
+  if (mediaType === 'show') return lib.type === 'show';
+  return true;
+}
+
 interface SmartRuleBuilderProps {
   isOpen: boolean;
   onClose: () => void;
@@ -249,14 +266,9 @@ export function SmartRuleBuilder({
     staleTime: 5 * 60 * 1000,
   });
 
-  // Only movie/show libraries can hold Prunerr-managed media; when the rule
-  // is movie- or show-only, narrow the choices to matching libraries.
-  const selectableLibraries = (plexLibraries ?? []).filter((lib) => {
-    if (lib.type !== 'movie' && lib.type !== 'show') return false;
-    if (mediaType === 'movie') return lib.type === 'movie';
-    if (mediaType === 'show') return lib.type === 'show';
-    return true;
-  });
+  const selectableLibraries = (plexLibraries ?? []).filter((lib) =>
+    isSelectableLibrary(lib, mediaType)
+  );
 
   const toggleLibraryKey = (key: string) => {
     setLibraryKeys((prev) =>
@@ -264,19 +276,13 @@ export function SmartRuleBuilder({
     );
   };
 
-  // Drop selected libraries that are no longer selectable after a media-type
-  // change (e.g. a show library was picked, then the rule narrowed to Movies).
+  // Drop selected libraries that are no longer selectable — after a media-type
+  // change (e.g. a show library was picked, then the rule narrowed to Movies)
+  // or after a library got excluded in settings.
   useEffect(() => {
     if (!plexLibraries) return;
     const valid = new Set(
-      plexLibraries
-        .filter((lib) => {
-          if (lib.type !== 'movie' && lib.type !== 'show') return false;
-          if (mediaType === 'movie') return lib.type === 'movie';
-          if (mediaType === 'show') return lib.type === 'show';
-          return true;
-        })
-        .map((lib) => lib.key)
+      plexLibraries.filter((lib) => isSelectableLibrary(lib, mediaType)).map((lib) => lib.key)
     );
     setLibraryKeys((prev) => {
       const next = prev.filter((k) => valid.has(k));

--- a/client/src/components/Rules/SmartRuleBuilder.tsx
+++ b/client/src/components/Rules/SmartRuleBuilder.tsx
@@ -19,7 +19,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
-import { rulesApi, RuleSuggestion } from '@/services/api';
+import { rulesApi, libraryApi, RuleSuggestion } from '@/services/api';
 import { Card } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
@@ -185,6 +185,7 @@ export function SmartRuleBuilder({
   const [ruleName, setRuleName] = useState('');
   const [priority, setPriority] = useState(0);
   const [mediaType, setMediaType] = useState<'all' | 'movie' | 'show'>('all');
+  const [libraryKeys, setLibraryKeys] = useState<string[]>([]);
   const [root, setRoot] = useState<ConditionGroupNode>(emptyRoot());
   const [gracePeriod, setGracePeriod] = useState(7);
   const [deletionAction, setDeletionAction] = useState<DeletionAction>('unmonitor_and_delete');
@@ -238,6 +239,51 @@ export function SmartRuleBuilder({
     enabled: isOpen,
   });
 
+  // Plex libraries for per-library rule targeting. Fails quietly (empty list)
+  // when Plex isn't configured — the selector simply doesn't render.
+  const { data: plexLibraries } = useQuery({
+    queryKey: ['plexLibraries'],
+    queryFn: libraryApi.getPlexLibraries,
+    enabled: isOpen,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Only movie/show libraries can hold Prunerr-managed media; when the rule
+  // is movie- or show-only, narrow the choices to matching libraries.
+  const selectableLibraries = (plexLibraries ?? []).filter((lib) => {
+    if (lib.type !== 'movie' && lib.type !== 'show') return false;
+    if (mediaType === 'movie') return lib.type === 'movie';
+    if (mediaType === 'show') return lib.type === 'show';
+    return true;
+  });
+
+  const toggleLibraryKey = (key: string) => {
+    setLibraryKeys((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]
+    );
+  };
+
+  // Drop selected libraries that are no longer selectable after a media-type
+  // change (e.g. a show library was picked, then the rule narrowed to Movies).
+  useEffect(() => {
+    if (!plexLibraries) return;
+    const valid = new Set(
+      plexLibraries
+        .filter((lib) => {
+          if (lib.type !== 'movie' && lib.type !== 'show') return false;
+          if (mediaType === 'movie') return lib.type === 'movie';
+          if (mediaType === 'show') return lib.type === 'show';
+          return true;
+        })
+        .map((lib) => lib.key)
+    );
+    setLibraryKeys((prev) => {
+      const next = prev.filter((k) => valid.has(k));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [mediaType, plexLibraries]);
+
   // Escape key handler
   useEffect(() => {
     if (!isOpen) return;
@@ -262,6 +308,7 @@ export function SmartRuleBuilder({
       const mt =
         editingRule.mediaType === 'tv' ? 'show' : (editingRule.mediaType || 'all');
       setMediaType(mt as 'all' | 'movie' | 'show');
+      setLibraryKeys(editingRule.libraryKeys ?? []);
       const loaded = rootFromRule(editingRule);
       const wrapped =
         loaded.kind === 'group' ? loaded : { kind: 'group' as const, logic: 'AND' as const, children: [loaded] };
@@ -275,6 +322,7 @@ export function SmartRuleBuilder({
       setRuleName('');
       setPriority(0);
       setMediaType('all');
+      setLibraryKeys([]);
       setRoot(emptyRoot());
       setGracePeriod(7);
       setDeletionAction('unmonitor_and_delete');
@@ -406,6 +454,7 @@ export function SmartRuleBuilder({
       type: deriveRuleType(root),
       action: 'delete',
       mediaType: finalMediaType,
+      libraryKeys,
       conditions: { version: 2, root: cleanRoot },
       gracePeriodDays: gracePeriod,
       deletionAction,
@@ -804,6 +853,50 @@ export function SmartRuleBuilder({
                 </div>
               </div>
 
+              {/* Library targeting — only shown when Plex libraries are known */}
+              {selectableLibraries.length > 0 && (
+                <div>
+                  <label className="block text-sm font-medium text-surface-200 mb-1">
+                    {t('fields.libraries', 'Libraries')}
+                  </label>
+                  <p className="text-xs text-surface-500 mb-2">
+                    {t('fields.librariesHint', 'Limit this rule to specific Plex libraries. Leave "All Libraries" selected to apply it everywhere.')}
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setLibraryKeys([])}
+                      className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                        libraryKeys.length === 0
+                          ? 'bg-accent-500/20 text-surface-50 ring-1 ring-inset ring-accent-500/50'
+                          : 'bg-surface-800 border border-surface-700 text-surface-300 hover:bg-surface-700 hover:text-surface-100'
+                      }`}
+                    >
+                      {t('fields.allLibraries', 'All Libraries')}
+                    </button>
+                    {selectableLibraries.map((lib) => {
+                      const selected = libraryKeys.includes(lib.key);
+                      const LibIcon = lib.type === 'movie' ? Film : Tv;
+                      return (
+                        <button
+                          key={lib.key}
+                          type="button"
+                          onClick={() => toggleLibraryKey(lib.key)}
+                          className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                            selected
+                              ? 'bg-accent-500/20 text-surface-50 ring-1 ring-inset ring-accent-500/50'
+                              : 'bg-surface-800 border border-surface-700 text-surface-300 hover:bg-surface-700 hover:text-surface-100'
+                          }`}
+                        >
+                          <LibIcon className="w-3.5 h-3.5" />
+                          {lib.title}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
               {/* Tree editor */}
               <div>
                 <label className="block text-sm font-medium text-surface-200 mb-2">
@@ -887,6 +980,7 @@ export function SmartRuleBuilder({
           <LivePreview
             root={mode === 'easy' ? easyRoot : root}
             mediaType={mode === 'easy' ? easySubject : mediaType}
+            libraryKeys={mode === 'easy' ? undefined : libraryKeys}
             enabled={mode === 'custom' || mode === 'easy'}
           />
         </div>
@@ -896,6 +990,7 @@ export function SmartRuleBuilder({
       <MobilePreviewSheet
         root={mode === 'easy' ? easyRoot : root}
         mediaType={mode === 'easy' ? easySubject : mediaType}
+        libraryKeys={mode === 'easy' ? undefined : libraryKeys}
         enabled={mode === 'custom' || mode === 'easy'}
       />
     </div>,

--- a/client/src/locales/de/rules.json
+++ b/client/src/locales/de/rules.json
@@ -24,6 +24,7 @@
     "gracePeriodDays_other": "{{count}} Tage",
     "gracePeriodLabel": "Schonfrist:",
     "inactive": "Inaktiv",
+    "libraryKey": "Bibliothek {{key}}",
     "priorityTooltip": "Regelpriorität (höhere gewinnt)",
     "runNow": "Regel jetzt ausführen",
     "v1Tooltip": "Veraltete v1-Regel",
@@ -132,9 +133,12 @@
     "select": "auswählen"
   },
   "fields": {
+    "allLibraries": "Alle Bibliotheken",
     "daysBeforeDeletion": "Tage vor dem Löschen",
     "deletionAction": "Löschaktion",
     "gracePeriod": "Schonfrist",
+    "libraries": "Bibliotheken",
+    "librariesHint": "Diese Regel auf bestimmte Plex-Bibliotheken beschränken. „Alle Bibliotheken\" ausgewählt lassen, um sie überall anzuwenden.",
     "priority": "Priorität",
     "resetSeerr": "In Seerr zurücksetzen",
     "resetSeerrDesc": "Benutzern erlauben, diesen Inhalt nach dem Löschen erneut anzufordern.",

--- a/client/src/locales/en/rules.json
+++ b/client/src/locales/en/rules.json
@@ -24,6 +24,7 @@
     "gracePeriodDays_other": "{{count}} days",
     "gracePeriodLabel": "Grace period:",
     "inactive": "Inactive",
+    "libraryKey": "Library {{key}}",
     "priorityTooltip": "Rule priority (higher wins)",
     "runNow": "Run rule now",
     "v1Tooltip": "v1 legacy rule",
@@ -132,9 +133,12 @@
     "select": "select"
   },
   "fields": {
+    "allLibraries": "All Libraries",
     "daysBeforeDeletion": "days before deletion",
     "deletionAction": "Deletion Action",
     "gracePeriod": "Grace Period",
+    "libraries": "Libraries",
+    "librariesHint": "Limit this rule to specific Plex libraries. Leave \"All Libraries\" selected to apply it everywhere.",
     "priority": "Priority",
     "resetSeerr": "Reset in Seerr",
     "resetSeerrDesc": "Allow users to re-request this content after deletion.",

--- a/client/src/locales/es/rules.json
+++ b/client/src/locales/es/rules.json
@@ -26,6 +26,7 @@
     "gracePeriodDays_other": "{{count}} días",
     "gracePeriodLabel": "Período de gracia:",
     "inactive": "Inactiva",
+    "libraryKey": "Biblioteca {{key}}",
     "priorityTooltip": "Prioridad de la regla (gana la más alta)",
     "runNow": "Ejecutar regla ahora",
     "v1Tooltip": "Regla heredada v1",
@@ -134,9 +135,12 @@
     "select": "seleccionar"
   },
   "fields": {
+    "allLibraries": "Todas las bibliotecas",
     "daysBeforeDeletion": "días antes de la eliminación",
     "deletionAction": "Acción de eliminación",
     "gracePeriod": "Período de gracia",
+    "libraries": "Bibliotecas",
+    "librariesHint": "Limita esta regla a bibliotecas de Plex específicas. Deja \"Todas las bibliotecas\" seleccionado para aplicarla en todas partes.",
     "priority": "Prioridad",
     "resetSeerr": "Restablecer en Seerr",
     "resetSeerrDesc": "Permite que los usuarios vuelvan a solicitar este contenido tras la eliminación.",

--- a/client/src/locales/fr/rules.json
+++ b/client/src/locales/fr/rules.json
@@ -26,6 +26,7 @@
     "gracePeriodDays_other": "{{count}} jours",
     "gracePeriodLabel": "Délai de grâce :",
     "inactive": "Inactive",
+    "libraryKey": "Bibliothèque {{key}}",
     "priorityTooltip": "Priorité de la règle (la plus élevée l'emporte)",
     "runNow": "Exécuter la règle maintenant",
     "v1Tooltip": "Règle héritée v1",
@@ -134,9 +135,12 @@
     "select": "sélectionner"
   },
   "fields": {
+    "allLibraries": "Toutes les bibliothèques",
     "daysBeforeDeletion": "jours avant suppression",
     "deletionAction": "Action de suppression",
     "gracePeriod": "Délai de grâce",
+    "libraries": "Bibliothèques",
+    "librariesHint": "Limiter cette règle à des bibliothèques Plex spécifiques. Laissez « Toutes les bibliothèques » sélectionné pour l'appliquer partout.",
     "priority": "Priorité",
     "resetSeerr": "Réinitialiser dans Seerr",
     "resetSeerrDesc": "Permettre aux utilisateurs de redemander ce contenu après suppression.",

--- a/client/src/locales/it/rules.json
+++ b/client/src/locales/it/rules.json
@@ -26,6 +26,7 @@
     "gracePeriodDays_other": "{{count}} giorni",
     "gracePeriodLabel": "Periodo di tolleranza:",
     "inactive": "Inattiva",
+    "libraryKey": "Libreria {{key}}",
     "priorityTooltip": "Priorità della regola (vince la più alta)",
     "runNow": "Esegui la regola adesso",
     "v1Tooltip": "Regola legacy v1",
@@ -134,9 +135,12 @@
     "select": "seleziona"
   },
   "fields": {
+    "allLibraries": "Tutte le librerie",
     "daysBeforeDeletion": "giorni prima dell'eliminazione",
     "deletionAction": "Azione di eliminazione",
     "gracePeriod": "Periodo di tolleranza",
+    "libraries": "Librerie",
+    "librariesHint": "Limita questa regola a librerie Plex specifiche. Lascia selezionato \"Tutte le librerie\" per applicarla ovunque.",
     "priority": "Priorità",
     "resetSeerr": "Reimposta in Seerr",
     "resetSeerrDesc": "Consenti agli utenti di richiedere nuovamente questo contenuto dopo l'eliminazione.",

--- a/client/src/locales/nl/rules.json
+++ b/client/src/locales/nl/rules.json
@@ -24,6 +24,7 @@
     "gracePeriodDays_other": "{{count}} dagen",
     "gracePeriodLabel": "Respijtperiode:",
     "inactive": "Inactief",
+    "libraryKey": "Bibliotheek {{key}}",
     "priorityTooltip": "Regelprioriteit (hoger wint)",
     "runNow": "Regel nu uitvoeren",
     "v1Tooltip": "v1 verouderde regel",
@@ -132,9 +133,12 @@
     "select": "selecteren"
   },
   "fields": {
+    "allLibraries": "Alle bibliotheken",
     "daysBeforeDeletion": "dagen vóór verwijdering",
     "deletionAction": "Verwijderactie",
     "gracePeriod": "Respijtperiode",
+    "libraries": "Bibliotheken",
+    "librariesHint": "Beperk deze regel tot specifieke Plex-bibliotheken. Laat \"Alle bibliotheken\" geselecteerd om hem overal toe te passen.",
     "priority": "Prioriteit",
     "resetSeerr": "Resetten in Seerr",
     "resetSeerrDesc": "Sta gebruikers toe deze inhoud opnieuw aan te vragen na verwijdering.",

--- a/client/src/locales/pt/rules.json
+++ b/client/src/locales/pt/rules.json
@@ -26,6 +26,7 @@
     "gracePeriodDays_other": "{{count}} dias",
     "gracePeriodLabel": "Período de tolerância:",
     "inactive": "Inativa",
+    "libraryKey": "Biblioteca {{key}}",
     "priorityTooltip": "Prioridade da regra (a mais alta prevalece)",
     "runNow": "Executar regra agora",
     "v1Tooltip": "Regra antiga v1",
@@ -134,9 +135,12 @@
     "select": "selecionar"
   },
   "fields": {
+    "allLibraries": "Todas as bibliotecas",
     "daysBeforeDeletion": "dias antes da eliminação",
     "deletionAction": "Ação de eliminação",
     "gracePeriod": "Período de tolerância",
+    "libraries": "Bibliotecas",
+    "librariesHint": "Limite esta regra a bibliotecas Plex específicas. Deixe \"Todas as bibliotecas\" selecionado para a aplicar em todo o lado.",
     "priority": "Prioridade",
     "resetSeerr": "Repor no Seerr",
     "resetSeerrDesc": "Permitir que os utilizadores voltem a solicitar este conteúdo após a eliminação.",

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -158,6 +158,13 @@ export const libraryApi = {
     });
     return data.data!;
   },
+
+  // List Plex libraries (used by the rule builder's library targeting and
+  // the settings exclusion config). Throws if Plex is not configured.
+  getPlexLibraries: async (): Promise<PlexLibrarySummary[]> => {
+    const { data } = await api.get<ApiResponse<PlexLibrarySummary[]>>('/library/plex-libraries');
+    return data.data || [];
+  },
 };
 
 // Bulk action result type
@@ -207,6 +214,15 @@ export interface RulePreviewV2Body {
   version: 2;
   root: import('@/types').ConditionNode;
   mediaType?: 'all' | 'movie' | 'show' | 'tv';
+  /** Restrict the preview to these Plex library keys. Empty/omitted = all. */
+  libraryKeys?: string[];
+}
+
+export interface PlexLibrarySummary {
+  key: string;
+  title: string;
+  type: string;
+  excluded: boolean;
 }
 
 export interface RuleSuggestion {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -114,6 +114,8 @@ export interface Rule {
   action: RuleAction;
   enabled: boolean;
   mediaType: 'all' | MediaType;
+  /** Plex library section keys the rule targets. Empty/undefined = all libraries. */
+  libraryKeys?: string[];
   /** v1 legacy flat array OR v2 tree. Server returns `conditionsV2` for tree form. */
   conditions: RuleCondition[] | RuleConditionsV2;
   /** v2 tree form populated by server on read. */

--- a/packaging/casaos/Prunerr/docker-compose.yml
+++ b/packaging/casaos/Prunerr/docker-compose.yml
@@ -2,7 +2,7 @@ name: prunerr
 
 services:
   prunerr:
-    image: helliott20/prunerr:1.5.11
+    image: helliott20/prunerr:1.5.12
     container_name: prunerr
     restart: unless-stopped
     network_mode: bridge
@@ -85,8 +85,8 @@ x-casaos:
   index: /
   port_map: "3000"
   scheme: http
-  version: "1.5.11"
-  updateAt: "2026-07-20"
+  version: "1.5.12"
+  updateAt: "2026-07-23"
   website: https://github.com/helliott20/prunerr
   repo: https://github.com/helliott20/prunerr
   support: https://forums.unraid.net/topic/196929-support-prunerr-media-library-cleanup-tool/

--- a/server/src/db/repositories/mediaItems.ts
+++ b/server/src/db/repositories/mediaItems.ts
@@ -31,6 +31,7 @@ interface MediaItemRow {
   play_count: number;
   watched_by: string | null;
   status: string;
+  library_key: string | null;
   marked_at: string | null;
   delete_after: string | null;
   deleted_at: string | null;

--- a/server/src/db/repositories/rules.ts
+++ b/server/src/db/repositories/rules.ts
@@ -26,6 +26,7 @@ interface RuleRow {
   profile_id: number | null;
   type: string;
   media_type: string | null;
+  library_keys: string | null;
   conditions: string;
   action: string;
   enabled: number;
@@ -37,6 +38,27 @@ interface RuleRow {
   updated_at: string;
 }
 
+/** Parse the stored library_keys JSON. Null/invalid/empty all mean "all libraries". */
+function parseLibraryKeys(value: string | null): string[] | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      const keys = parsed.map(String).filter((k) => k.trim() !== '');
+      return keys.length > 0 ? keys : null;
+    }
+  } catch {
+    logger.warn(`Failed to parse rule library_keys: ${value}`);
+  }
+  return null;
+}
+
+/** Serialize library keys for storage. Empty/null collapses to NULL (= all libraries). */
+function serializeLibraryKeys(keys: string[] | null | undefined): string | null {
+  if (!keys || keys.length === 0) return null;
+  return JSON.stringify(keys);
+}
+
 function rowToRule(row: RuleRow): Rule {
   return {
     id: row.id,
@@ -44,6 +66,7 @@ function rowToRule(row: RuleRow): Rule {
     profile_id: row.profile_id,
     type: row.type as RuleType,
     media_type: (row.media_type || 'all') as RuleMediaType,
+    library_keys: parseLibraryKeys(row.library_keys),
     conditions: row.conditions,
     action: row.action as RuleAction,
     enabled: Boolean(row.enabled),
@@ -88,8 +111,8 @@ export function createRule(input: CreateRuleInput): Rule {
   const now = new Date().toISOString();
 
   const stmt = db.prepare(`
-    INSERT INTO rules (name, profile_id, type, media_type, conditions, action, enabled, grace_period_days, deletion_action, reset_overseerr, priority, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO rules (name, profile_id, type, media_type, library_keys, conditions, action, enabled, grace_period_days, deletion_action, reset_overseerr, priority, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const result = stmt.run(
@@ -97,6 +120,7 @@ export function createRule(input: CreateRuleInput): Rule {
     input.profile_id ?? null,
     input.type,
     input.media_type ?? 'all',
+    serializeLibraryKeys(input.library_keys),
     JSON.stringify(input.conditions),
     input.action,
     input.enabled !== false ? 1 : 0,
@@ -144,6 +168,10 @@ export function updateRule(id: number, input: UpdateRuleInput): Rule | null {
   if (input.media_type !== undefined) {
     updates.push('media_type = ?');
     params.push(input.media_type);
+  }
+  if (input.library_keys !== undefined) {
+    updates.push('library_keys = ?');
+    params.push(serializeLibraryKeys(input.library_keys));
   }
   if (input.conditions !== undefined) {
     updates.push('conditions = ?');

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -408,6 +408,16 @@ const migrations: Migration[] = [
       WHERE status = 'pending_deletion' AND delete_after IS NULL;
     `,
   },
+  {
+    version: 19,
+    name: 'add_rule_library_keys',
+    up: `
+      -- Optional per-rule Plex library targeting. Stores a JSON array of
+      -- Plex library section keys (e.g. '["1","5"]'). NULL means the rule
+      -- applies to every library (existing behaviour).
+      ALTER TABLE rules ADD COLUMN library_keys TEXT;
+    `,
+  },
 ];
 
 // Schema version tracking table

--- a/server/src/routes/__tests__/rulesPreview.test.ts
+++ b/server/src/routes/__tests__/rulesPreview.test.ts
@@ -50,12 +50,12 @@ function daysAgo(n: number): string {
   return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
 }
 
-function seedMovie(title: string, status: string, addedDaysAgo: number) {
+function seedMovie(title: string, status: string, addedDaysAgo: number, libraryKey: string | null = '1') {
   const item = createMediaItem({
     type: 'movie',
     title,
     plex_id: `rk-${title}`,
-    library_key: '1',
+    ...(libraryKey !== null ? { library_key: libraryKey } : {}),
     play_count: 0,
     added_at: daysAgo(addedDaysAgo),
   } as never);
@@ -149,5 +149,30 @@ describe('POST /api/rules/preview', () => {
     const data = await preview(NEVER_WATCHED_180D);
 
     expect(data.totalMatches).toBe(1);
+  });
+
+  it('restricts matches to the targeted libraries when libraryKeys is set', async () => {
+    seedMovie('anime-1', 'monitored', 400, '2');
+    seedMovie('anime-2', 'monitored', 400, '2');
+    seedMovie('regular-1', 'monitored', 400, '1');
+    seedMovie('no-library', 'monitored', 400, null);
+
+    const data = await preview({ ...NEVER_WATCHED_180D, libraryKeys: ['2'] });
+
+    // Only the two items in library 2 count; the legacy item without a
+    // library_key is excluded from a library-restricted preview.
+    expect(data.totalMatches).toBe(2);
+  });
+
+  it('matches all libraries when libraryKeys is empty or omitted', async () => {
+    seedMovie('lib1', 'monitored', 400, '1');
+    seedMovie('lib2', 'monitored', 400, '2');
+    seedMovie('unkeyed', 'monitored', 400, null);
+
+    const omitted = await preview(NEVER_WATCHED_180D);
+    expect(omitted.totalMatches).toBe(3);
+
+    const empty = await preview({ ...NEVER_WATCHED_180D, libraryKeys: [] });
+    expect(empty.totalMatches).toBe(3);
   });
 });

--- a/server/src/routes/rules.ts
+++ b/server/src/routes/rules.ts
@@ -12,6 +12,7 @@ import {
   type EvaluationContext,
 } from '../rules/engine';
 import { buildEvaluationContext } from '../rules/context';
+import { ruleScopeMatches } from '../rules/scope';
 import type { ConditionNode } from '../rules/types';
 import logger from '../utils/logger';
 import { formatBytes } from '../utils/format';
@@ -107,6 +108,8 @@ interface ClientRule {
   profileId: number | null;
   type: string;
   mediaType: 'all' | 'movie' | 'tv';
+  /** Plex library section keys the rule targets. Empty = all libraries. */
+  libraryKeys: string[];
   conditions: string;
   /**
    * v2 parsed condition tree — the stored JSON is upgraded on read so the
@@ -139,6 +142,7 @@ function toClientRule(rule: Rule): ClientRule {
     profileId: rule.profile_id,
     type: rule.type,
     mediaType: clientMediaType as 'all' | 'movie' | 'tv',
+    libraryKeys: rule.library_keys ?? [],
     conditions: rule.conditions,
     conditionsV2,
     action: rule.action,
@@ -237,7 +241,7 @@ function getFieldValue(item: MediaItem, field: string): string | number | boolea
     case 'codec':
       return (item.codec || '').toLowerCase();
     case 'library_key':
-      return (item as any).library_key || '';
+      return item.library_key || '';
     case 'file_path':
       return item.file_path || '';
     case 'watched_by_count': {
@@ -885,11 +889,8 @@ router.post('/:id/run', async (req: Request, res: Response) => {
     const mediaItemsRepo = await import('../db/repositories/mediaItems');
     const mediaItems = mediaItemsRepo.default.fetchAll({ excludeDeleted: true });
 
-    // Filter by media type if specified
-    const ruleMediaType = rule.media_type || 'all';
-    const filteredItems = ruleMediaType === 'all'
-      ? mediaItems
-      : mediaItems.filter((item) => item.type === ruleMediaType);
+    // Filter by rule scope (media type + targeted libraries)
+    const filteredItems = mediaItems.filter((item) => ruleScopeMatches(rule, item));
 
     // Build evaluation context once for this run (v2 engine — supports nested
     // groups, new operators, collection_membership, watched_by_user)
@@ -1011,6 +1012,7 @@ router.post('/:id/run', async (req: Request, res: Response) => {
 // Accepts either v1 (legacy flat conditions) or v2 (nested tree) payloads.
 const PreviewRuleSchema = z.object({
   mediaType: z.enum(['all', 'movie', 'show', 'tv']).optional(),
+  libraryKeys: z.array(z.string().min(1)).max(100).optional(),
   // v2
   version: z.literal(2).optional(),
   root: ConditionNodeSchema.optional(),
@@ -1029,7 +1031,10 @@ const PreviewRuleSchema = z.object({
 
 router.post('/preview', validateBody(PreviewRuleSchema), async (req: Request, res: Response) => {
   try {
-    const { mediaType } = req.body;
+    const { mediaType, libraryKeys } = req.body as {
+      mediaType?: string;
+      libraryKeys?: string[];
+    };
 
     // Build v2 tree from payload
     let v2;
@@ -1059,10 +1064,20 @@ router.post('/preview', validateBody(PreviewRuleSchema), async (req: Request, re
 
     // Normalize mediaType: client 'tv' → server 'show'
     const normalizedType = mediaType === 'tv' ? 'show' : mediaType;
-    const items =
+    const typeFiltered =
       !normalizedType || normalizedType === 'all'
         ? allItems
         : allItems.filter((item) => item.type === normalizedType);
+
+    // Restrict to targeted Plex libraries when the rule names any. Items with
+    // no library_key (legacy rows) fall outside a library-restricted rule,
+    // mirroring ruleScopeMatches.
+    const items =
+      libraryKeys && libraryKeys.length > 0
+        ? typeFiltered.filter(
+            (item) => item.library_key != null && libraryKeys.includes(item.library_key)
+          )
+        : typeFiltered;
 
     // Build watch lookup from cache (one-time prefetch for this run)
     const ctx: EvaluationContext = buildEvaluationContext();

--- a/server/src/rules/__tests__/scope.test.ts
+++ b/server/src/rules/__tests__/scope.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { ruleScopeMatches } from '../scope';
+import type { MediaItem, Rule } from '../../types';
+
+function makeRule(overrides: Partial<Rule> = {}): Rule {
+  return {
+    id: 1,
+    name: 'test rule',
+    profile_id: null,
+    type: 'custom',
+    media_type: 'all',
+    library_keys: null,
+    conditions: '{"version":2,"root":{"kind":"group","logic":"AND","children":[]}}',
+    action: 'delete',
+    enabled: true,
+    grace_period_days: 7,
+    deletion_action: 'unmonitor_and_delete',
+    reset_overseerr: false,
+    priority: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<MediaItem> = {}): MediaItem {
+  return {
+    id: 1,
+    type: 'movie',
+    title: 'Test Movie',
+    plex_id: 'rk-1',
+    sonarr_id: null,
+    radarr_id: null,
+    tmdb_id: null,
+    imdb_id: null,
+    tvdb_id: null,
+    year: 2020,
+    poster_url: null,
+    file_path: null,
+    file_size: null,
+    resolution: null,
+    codec: null,
+    added_at: null,
+    last_watched_at: null,
+    play_count: 0,
+    watched_by: null,
+    status: 'monitored',
+    library_key: '1',
+    marked_at: null,
+    delete_after: null,
+    deleted_at: null,
+    is_protected: false,
+    protection_reason: null,
+    genres: null,
+    tags: null,
+    studio: null,
+    audio_codec: null,
+    video_codec: null,
+    hdr: null,
+    bitrate: null,
+    runtime_minutes: null,
+    season_count: null,
+    episode_count: null,
+    series_status: null,
+    rating_imdb: null,
+    rating_tmdb: null,
+    rating_rt: null,
+    content_rating: null,
+    original_language: null,
+    requested_by: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('ruleScopeMatches', () => {
+  describe('media type scoping (existing behaviour)', () => {
+    it('matches any type when media_type is all', () => {
+      const rule = makeRule({ media_type: 'all' });
+      expect(ruleScopeMatches(rule, makeItem({ type: 'movie' }))).toBe(true);
+      expect(ruleScopeMatches(rule, makeItem({ type: 'show' }))).toBe(true);
+    });
+
+    it('restricts to the configured media type', () => {
+      const rule = makeRule({ media_type: 'movie' });
+      expect(ruleScopeMatches(rule, makeItem({ type: 'movie' }))).toBe(true);
+      expect(ruleScopeMatches(rule, makeItem({ type: 'show' }))).toBe(false);
+    });
+  });
+
+  describe('library scoping', () => {
+    it('matches every library when library_keys is null', () => {
+      const rule = makeRule({ library_keys: null });
+      expect(ruleScopeMatches(rule, makeItem({ library_key: '1' }))).toBe(true);
+      expect(ruleScopeMatches(rule, makeItem({ library_key: '99' }))).toBe(true);
+      expect(ruleScopeMatches(rule, makeItem({ library_key: null }))).toBe(true);
+    });
+
+    it('matches every library when library_keys is empty', () => {
+      const rule = makeRule({ library_keys: [] });
+      expect(ruleScopeMatches(rule, makeItem({ library_key: '7' }))).toBe(true);
+    });
+
+    it('matches only items in a targeted library', () => {
+      const rule = makeRule({ library_keys: ['2', '5'] });
+      expect(ruleScopeMatches(rule, makeItem({ library_key: '2' }))).toBe(true);
+      expect(ruleScopeMatches(rule, makeItem({ library_key: '5' }))).toBe(true);
+      expect(ruleScopeMatches(rule, makeItem({ library_key: '1' }))).toBe(false);
+    });
+
+    it('excludes items with no library_key from library-restricted rules', () => {
+      const rule = makeRule({ library_keys: ['1'] });
+      expect(ruleScopeMatches(rule, makeItem({ library_key: null }))).toBe(false);
+      expect(ruleScopeMatches(rule, makeItem({ library_key: undefined }))).toBe(false);
+    });
+  });
+
+  describe('combined scoping', () => {
+    it('requires both media type and library to match', () => {
+      const rule = makeRule({ media_type: 'movie', library_keys: ['3'] });
+      expect(ruleScopeMatches(rule, makeItem({ type: 'movie', library_key: '3' }))).toBe(true);
+      expect(ruleScopeMatches(rule, makeItem({ type: 'show', library_key: '3' }))).toBe(false);
+      expect(ruleScopeMatches(rule, makeItem({ type: 'movie', library_key: '4' }))).toBe(false);
+    });
+  });
+});

--- a/server/src/rules/scope.ts
+++ b/server/src/rules/scope.ts
@@ -1,0 +1,28 @@
+import type { MediaItem, Rule } from '../types';
+
+/**
+ * Check whether a rule's targeting scope (media type + Plex libraries)
+ * covers a media item. This runs BEFORE condition evaluation — an item
+ * outside the rule's scope is never evaluated against its conditions.
+ *
+ * Library targeting semantics:
+ * - `library_keys` null/empty → the rule applies to every library.
+ * - Otherwise the item's `library_key` must be one of the targeted keys.
+ *   Items with no library_key (legacy rows synced before the column
+ *   existed) are treated as out of scope for library-restricted rules,
+ *   so a targeted rule never deletes content whose library is unknown.
+ */
+export function ruleScopeMatches(rule: Rule, item: MediaItem): boolean {
+  const ruleMediaType = rule.media_type || 'all';
+  if (ruleMediaType !== 'all' && ruleMediaType !== item.type) {
+    return false;
+  }
+
+  const libraryKeys = rule.library_keys;
+  if (libraryKeys && libraryKeys.length > 0) {
+    if (!item.library_key) return false;
+    return libraryKeys.includes(item.library_key);
+  }
+
+  return true;
+}

--- a/server/src/scheduler/tasks.ts
+++ b/server/src/scheduler/tasks.ts
@@ -10,6 +10,7 @@ import { PlexUsersService } from '../services/plexUsers';
 import { isSyncInProgress, runLibrarySync } from '../services/syncCoordinator';
 import { logActivity } from '../db/repositories/activity';
 import { evaluateRuleConditions } from '../rules/engine';
+import { ruleScopeMatches } from '../rules/scope';
 import { buildEvaluationContext } from '../rules/context';
 import { getNotificationService } from '../notifications';
 import { getUsageForPaths, resolveTargetBytes, GiB, type FsUsage, type TargetMode } from '../services/diskSpace';
@@ -394,12 +395,9 @@ export async function scanLibraries(): Promise<ScanResult> {
 
       // Check each rule
       for (const rule of enabledRules) {
-        // Skip rule if media type doesn't match
-        const ruleMediaType = rule.media_type || 'all';
-        if (ruleMediaType !== 'all') {
-          if (ruleMediaType !== item.type) {
-            continue;
-          }
+        // Skip rule if the item is outside its scope (media type / libraries)
+        if (!ruleScopeMatches(rule, item)) {
+          continue;
         }
 
         const matches = evaluateRuleConditions(rule.conditions, item, ctx);

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -44,6 +44,8 @@ export interface MediaItem {
   play_count: number;
   watched_by: string | null; // JSON array of user names
   status: MediaStatus;
+  /** Plex library section key the item was synced from (null for legacy rows). */
+  library_key?: string | null;
   marked_at: string | null;
   delete_after: string | null;
   deleted_at: string | null;
@@ -87,6 +89,8 @@ export interface Rule {
   profile_id: number | null;
   type: RuleType;
   media_type: RuleMediaType;
+  /** Plex library section keys the rule targets. Null/empty = all libraries. */
+  library_keys: string[] | null;
   conditions: string; // JSON array of RuleCondition
   action: RuleAction;
   enabled: boolean;
@@ -232,6 +236,7 @@ export interface CreateRuleInput {
   profile_id?: number;
   type: RuleType;
   media_type?: RuleMediaType;
+  library_keys?: string[] | null;
   conditions: RuleConditionsPayload;
   action: RuleAction;
   enabled?: boolean;
@@ -246,6 +251,7 @@ export interface UpdateRuleInput {
   profile_id?: number;
   type?: RuleType;
   media_type?: RuleMediaType;
+  library_keys?: string[] | null;
   conditions?: RuleConditionsPayload;
   action?: RuleAction;
   enabled?: boolean;
@@ -435,6 +441,15 @@ export const RuleMediaTypeSchema = z.union([
 
 export const DeletionActionSchema = z.enum(['unmonitor_only', 'delete_files_only', 'unmonitor_and_delete', 'full_removal']);
 
+/**
+ * Plex library section keys targeted by a rule. Empty array and null both
+ * mean "all libraries" and are normalized to null at the repository layer.
+ */
+export const RuleLibraryKeysSchema = z
+  .array(z.string().min(1))
+  .max(100)
+  .nullable();
+
 export const CreateRuleSchema = z.object({
   name: z.string().min(1),
   profile_id: z.number().optional(),
@@ -442,6 +457,9 @@ export const CreateRuleSchema = z.object({
   // Accept both snake_case and camelCase for mediaType
   media_type: RuleMediaTypeSchema.optional(),
   mediaType: RuleMediaTypeSchema.optional(),
+  // Accept both snake_case and camelCase for libraryKeys
+  library_keys: RuleLibraryKeysSchema.optional(),
+  libraryKeys: RuleLibraryKeysSchema.optional(),
   conditions: RuleConditionsInputSchema,
   action: RuleActionSchema,
   enabled: z.boolean().optional().default(true),
@@ -449,9 +467,10 @@ export const CreateRuleSchema = z.object({
   deletionAction: DeletionActionSchema.optional(),
   resetOverseerr: z.boolean().optional(),
   priority: z.number().int().min(0).max(100).optional().default(0),
-}).transform(({ mediaType, ...rest }) => ({
+}).transform(({ mediaType, libraryKeys, ...rest }) => ({
   ...rest,
   media_type: rest.media_type || mediaType || 'all',
+  library_keys: rest.library_keys !== undefined ? rest.library_keys : libraryKeys ?? null,
 }));
 
 export const UpdateRuleSchema = z.object({
@@ -460,6 +479,8 @@ export const UpdateRuleSchema = z.object({
   type: RuleTypeSchema.optional(),
   media_type: RuleMediaTypeSchema.optional(),
   mediaType: RuleMediaTypeSchema.optional(),
+  library_keys: RuleLibraryKeysSchema.optional(),
+  libraryKeys: RuleLibraryKeysSchema.optional(),
   conditions: RuleConditionsInputSchema.optional(),
   action: RuleActionSchema.optional(),
   enabled: z.boolean().optional(),
@@ -467,9 +488,10 @@ export const UpdateRuleSchema = z.object({
   deletionAction: DeletionActionSchema.optional(),
   resetOverseerr: z.boolean().optional(),
   priority: z.number().int().min(0).max(100).optional(),
-}).transform(({ mediaType, ...rest }) => ({
+}).transform(({ mediaType, libraryKeys, ...rest }) => ({
   ...rest,
   media_type: rest.media_type || mediaType,
+  library_keys: rest.library_keys !== undefined ? rest.library_keys : libraryKeys,
 }));
 
 export const SettingInputSchema = z.object({


### PR DESCRIPTION
Implements the idea from discussion #51 (thanks @NolleMania): rules can now target specific Plex libraries instead of only the movie/TV split — e.g. one rule set for a "trending movies" library and another for an "anime" library.

## Server

- **Migration 19** adds `rules.library_keys` — a JSON array of Plex section keys; `NULL`/empty means all libraries, so every existing rule keeps its current behaviour.
- New `ruleScopeMatches()` helper (`server/src/rules/scope.ts`) checks media type + library scope together, applied consistently in all three evaluation paths: scheduled scans, manual rule runs, and the preview endpoint.
- Safety: items with no `library_key` (legacy rows synced before that column existed) never match a library-restricted rule, so a targeted rule can't touch content whose library is unknown. A library sync fills the keys in.
- API accepts `libraryKeys` on create/update and returns it on read; preview accepts an optional `libraryKeys` filter.

## Client

- "Libraries" chip picker in the Custom Builder (fed by the existing `/api/library/plex-libraries` endpoint). Only **included** movie/show libraries are offered — excluded libraries are never scanned, so targeting them would create rules that silently match nothing. Choices narrow to the rule's media type, and stale selections are pruned when the media type or exclusions change.
- Live preview (desktop panel + mobile sheet) respects the selected libraries.
- Rule cards show a badge per targeted library, resolved to the library's display name.
- New strings translated in all 7 locales.

## Release prep

- CasaOS manifest bumped to `1.5.12` (image tag, `x-casaos.version`, `updateAt`).

## Testing

- Server: 108/108 tests pass, including a new `scope.test.ts` suite and preview-endpoint tests for library filtering and legacy-item exclusion.
- Client: build + 35/35 tests pass.
- Verified live on a phone against a real install (beta image `1.5.12-beta.x`): picker renders, excluded libraries hidden after the fix, badges show on rule cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3hHkgckJFrKNigS9fiiaN

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3hHkgckJFrKNigS9fiiaN)_