### PR TITLE
Backfill library_key on sync updates so older items match library rules

### DIFF
--- a/packaging/casaos/Prunerr/docker-compose.yml
+++ b/packaging/casaos/Prunerr/docker-compose.yml
@@ -2,7 +2,7 @@ name: prunerr
 
 services:
   prunerr:
-    image: helliott20/prunerr:1.5.12
+    image: helliott20/prunerr:1.5.13
     container_name: prunerr
     restart: unless-stopped
     network_mode: bridge
@@ -85,7 +85,7 @@ x-casaos:
   index: /
   port_map: "3000"
   scheme: http
-  version: "1.5.12"
+  version: "1.5.13"
   updateAt: "2026-07-23"
   website: https://github.com/helliott20/prunerr
   repo: https://github.com/helliott20/prunerr

--- a/server/src/db/repositories/__tests__/updateLibraryKey.test.ts
+++ b/server/src/db/repositories/__tests__/updateLibraryKey.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import fs from 'fs';
+
+// Real on-disk SQLite (better-sqlite3 needs a file for WAL). Point config at a
+// temp DB before the db module reads it, and silence the logger. Computed via
+// vi.hoisted so it's available inside the hoisted vi.mock factory below.
+const { tmpDbPath } = vi.hoisted(() => {
+  const osMod = require('os');
+  const pathMod = require('path');
+  return {
+    tmpDbPath: pathMod.join(osMod.tmpdir(), `prunerr-libkey-test-${process.pid}-${Date.now()}.db`),
+  };
+});
+
+vi.mock('../../../config', () => ({
+  default: { dbPath: tmpDbPath, nodeEnv: 'test' },
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { initializeDatabase, getDatabase, closeDatabase } from '../../index';
+import { createMediaItem, updateMediaItem, getMediaItemById } from '../mediaItems';
+
+describe('updateMediaItem library_key', () => {
+  beforeAll(() => {
+    initializeDatabase();
+  });
+
+  afterAll(() => {
+    closeDatabase();
+    for (const suffix of ['', '-wal', '-shm']) {
+      try { fs.unlinkSync(tmpDbPath + suffix); } catch { /* ignore */ }
+    }
+  });
+
+  beforeEach(() => {
+    getDatabase().prepare('DELETE FROM media_items').run();
+  });
+
+  it('backfills library_key on rows created without one (pre-migration items)', () => {
+    // Rows created before the library_key column existed have NULL — a sync
+    // update must be able to fill it in, or library-targeted rules can never
+    // match older content.
+    const item = createMediaItem({ type: 'movie', title: 'Old Movie', plex_id: 'rk-old' });
+    expect(getMediaItemById(item.id)?.library_key ?? null).toBeNull();
+
+    updateMediaItem(item.id, { title: 'Old Movie', library_key: '1' });
+
+    expect(getMediaItemById(item.id)?.library_key).toBe('1');
+  });
+
+  it('updates library_key when an item moves between Plex libraries', () => {
+    const item = createMediaItem({ type: 'movie', title: 'Mover', plex_id: 'rk-mover', library_key: '1' });
+
+    updateMediaItem(item.id, { library_key: '4' });
+
+    expect(getMediaItemById(item.id)?.library_key).toBe('4');
+  });
+
+  it('leaves library_key untouched when the update omits it', () => {
+    const item = createMediaItem({ type: 'movie', title: 'Keeper', plex_id: 'rk-keeper', library_key: '2' });
+
+    updateMediaItem(item.id, { title: 'Keeper (renamed)' });
+
+    expect(getMediaItemById(item.id)?.library_key).toBe('2');
+  });
+});

--- a/server/src/db/repositories/mediaItems.ts
+++ b/server/src/db/repositories/mediaItems.ts
@@ -399,6 +399,10 @@ export function updateMediaItem(id: number, input: UpdateMediaItemInput): MediaI
     updates.push('status = ?');
     params.push(input.status);
   }
+  if (input.library_key !== undefined) {
+    updates.push('library_key = ?');
+    params.push(input.library_key);
+  }
   if (input.marked_at !== undefined) {
     updates.push('marked_at = ?');
     params.push(input.marked_at);


### PR DESCRIPTION
Fixes a bug found while testing #52 on a real install: a rule with **Applies to: Movies** matched an item, but the same rule with **All Media + the "Movies" library selected** matched nothing.

## Root cause

`updateMediaItem()` had no case for `library_key`. Items created before the column existed (migration 9) have `NULL`, and although every sync passes the key on update, it was silently dropped — so older items could never carry a library tag. The media-type filter checks `item.type` (works for all items), while library targeting checks `item.library_key` (NULL for pre-migration items), hence the discrepancy.

## Fix

- Add the missing `library_key` case to `updateMediaItem()`, so the next library sync backfills keys on all existing rows.
- Regression tests: backfill on NULL rows, key updates when an item moves libraries, and no-op when omitted.
- CasaOS manifest bumped to `1.5.13` (v1.5.12 is already tagged).

## Testing

- Server: 111/111 tests pass (3 new), typecheck clean.
- After upgrading, one library sync repairs existing data — no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3hHkgckJFrKNigS9fiiaN

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3hHkgckJFrKNigS9fiiaN)_